### PR TITLE
Emit data architecture events

### DIFF
--- a/.jules/exchange/events/duplicate_semver_parsing_data_arch.md
+++ b/.jules/exchange/events/duplicate_semver_parsing_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-20"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Duplicate semver parsing logic across different modules. Both `src/domain/version-token.ts` and `src/adapters/cache/binary-install-cache.ts` implement custom regex-based semver parsing logic to extract version strings without the 'v' prefix.
+
+## Goal
+
+Centralize semver parsing logic into a single Source of Truth (SSOT) domain module to eliminate duplicate definitions and ensure consistent version validation and parsing behavior.
+
+## Context
+
+The repository has multiple places where version strings are extracted and normalized (removing 'v' prefix and matching against standard `\d+\.\d+\.\d+` format). This violates the "Single Source of Truth" first principle of data architecture where each concept should have one canonical representation and owner.
+
+## Evidence
+
+- path: "src/domain/version-token.ts"
+  loc: "5-17"
+  note: "Defines `SEMVER_PATTERN = /^\\d+\\.\\d+\\.\\d+$/` and implements `semverCore = normalized.replace(/^v/, '')` followed by pattern test."
+- path: "src/adapters/cache/binary-install-cache.ts"
+  loc: "110-117"
+  note: "Implements `extractFirstSemverTriplet` with identical logic: `normalized = token.replace(/^v/, '')` and `/^\\d+\\.\\d+\\.\\d+$/.test(normalized)`."
+
+## Change Scope
+
+- `src/domain/version-token.ts`
+- `src/adapters/cache/binary-install-cache.ts`

--- a/.jules/exchange/events/missing_api_response_validation_data_arch.md
+++ b/.jules/exchange/events/missing_api_response_validation_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-20"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Missing data validation for GitHub API responses. The codebase uses loose type assertions (`as {...}`) instead of explicit schema validation for incoming JSON data from external APIs.
+
+## Goal
+
+Encode invariants at boundaries to rule out invalid states explicitly instead of trusting the external payload via assertions.
+
+## Context
+
+Using `as Type` on `response.json()` circumvents TypeScript's safety guarantees and violates the "Represent Valid States Only" principle. It shifts the burden of validation to implicit runtime failure instead of creating an explicit parsing boundary where invalid data is caught and modeled as an error.
+
+## Evidence
+
+- path: "src/adapters/github/release-asset-api.ts"
+  loc: "37"
+  note: "`const metadata = (await metadataResponse.json()) as { assets?: Array<{ id: number; name: string }> }` blindly trusts the external payload structure."
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "32"
+  note: "`const user = (await response.json()) as { login?: string; type?: string }` uses unsafe type assertions over explicit validation logic."
+
+## Change Scope
+
+- `src/adapters/github/release-asset-api.ts`
+- `src/adapters/github/github-git-http-username.ts`

--- a/.jules/exchange/events/transport_dto_leak_data_arch.md
+++ b/.jules/exchange/events/transport_dto_leak_data_arch.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-03-20"
+author_role: "data_arch"
+confidence: "medium"
+---
+
+## Problem
+
+`InstallRequest` couples transport-level variables from `process.env` (e.g. `runnerEnvironment`, `runnerTemp`, `runnerToolCache`, `JLO_ALLOW_DARWIN_X86_64_FALLBACK`) directly into the core installation logic.
+
+## Goal
+
+Ensure `InstallRequest` maps environment-specific inputs to pure domain facts rather than propagating external terminology directly into internal logic.
+
+## Context
+
+Data architecture anti-pattern: "Transport DTOs or persistence types leaking into core domain logic". Passing action runner internals deep into `app/install-release.ts` and `app/install-main-source.ts` via `InstallRequest` blurs the boundary between external execution context and the application core.
+
+## Evidence
+
+- path: "src/action/install-request.ts"
+  loc: "5-9"
+  note: "Defines properties like `runnerEnvironment`, `runnerTemp`, `runnerToolCache` rather than abstracted path concepts."
+- path: "src/adapters/cache/binary-install-cache.ts"
+  loc: "12-25"
+  note: "`resolveCacheRoot` directly inspects string values like `github-hosted` on the options interface to calculate paths, pulling transport logic into the adapter."
+
+## Change Scope
+
+- `src/action/install-request.ts`
+- `src/app/install-release.ts`
+- `src/app/install-main-source.ts`
+- `src/adapters/cache/binary-install-cache.ts`


### PR DESCRIPTION
Creates 3 event files in `.jules/exchange/events/` capturing data architecture anti-patterns found in the repository.

---
*PR created automatically by Jules for task [6768198315684402072](https://jules.google.com/task/6768198315684402072) started by @akitorahayashi*