### PR TITLE
Emit test coverage risk events

### DIFF
--- a/.jules/exchange/events/app_install_cov.md
+++ b/.jules/exchange/events/app_install_cov.md
@@ -1,0 +1,34 @@
+---
+label: "tests"
+created_at: "2026-03-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Crucial execution paths within `src/app/install-release.ts` and `src/app/install-main-source.ts` lack robust coverage, especially around error conditions and the actual file operations.
+
+## Goal
+
+Ensure that tests exist for core application flows, particularly caching hits/misses, and failure modes during git/cargo operations or binary fetching.
+
+## Context
+
+The main installation logic for `setup-jlo` dictates either a source build or fetching a release asset. Currently, both modules (`src/app/install-main-source.ts` and `src/app/install-release.ts`) demonstrate large coverage gaps (`install-release.ts` at 55.55% and `install-main-source.ts` at 88.23%). The missing lines (such as `install-release.ts` lines 48-59, 67-81 and `install-main-source.ts` lines 30-33, 93-96) relate directly to downloading/building failure modes, temporary directory management, and caching checks. These are the highest-risk workflows in the tool; incomplete coverage implies that file IO or git failures might not be caught, leaving behind bad state or unhelpful error messages.
+
+## Evidence
+
+- path: "src/app/install-release.ts"
+  loc: "Lines 48-59, 67-81"
+  note: "Uncovered error branches regarding empty download sizes, and temp dir cleanup logic on failures."
+- path: "src/app/install-main-source.ts"
+  loc: "Lines 30-33, 93-96"
+  note: "Uncovered error paths for when submodule tokens are absent, or when git submodule updates fail."
+
+## Change Scope
+
+- `src/app/install-release.ts`
+- `tests/app/install-release.test.ts`
+- `src/app/install-main-source.ts`
+- `tests/app/install-main-source.test.ts`

--- a/.jules/exchange/events/github_git_http_username_cov.md
+++ b/.jules/exchange/events/github_git_http_username_cov.md
@@ -1,0 +1,35 @@
+---
+label: "tests"
+created_at: "2026-03-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The error paths in `src/adapters/github/github-git-http-username.ts` are heavily under-tested, creating a blind spot for GitHub token authentication failures.
+
+## Goal
+
+Ensure that test coverage for GitHub HTTP username resolution adequately covers critical failure modes (401, 403, and JSON parsing failures) to prevent silent auth regressions.
+
+## Context
+
+The module `src/adapters/github/github-git-http-username.ts` is responsible for fetching the username associated with a GitHub token. This is a critical security and authentication boundary for cloning `jlo` source code or fetching submodules. The test coverage report shows that lines 21-24, 27-30, and 41-44 are uncovered. These correspond directly to the HTTP error response handling (401/403 and non-ok statuses) and missing username field handling. If changes break these error paths, the action may fail with opaque, unhelpful errors or retry infinitely instead of bubbling up a clear authorization error.
+
+## Evidence
+
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "Lines 21-24"
+  note: "Uncovered error block for handling 401/403 responses. Missing tests for expired/unauthorized tokens."
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "Lines 27-30"
+  note: "Uncovered error block for handling non-ok HTTP statuses (e.g., 500). Missing tests for API failures."
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "Lines 41-44"
+  note: "Uncovered error block for when the API returns a response without a usable login. Missing tests for invalid payloads."
+
+## Change Scope
+
+- `src/adapters/github/github-git-http-username.ts`
+- `tests/adapters/github-git-http-username.test.ts`

--- a/.jules/exchange/events/platform_fallback_cov.md
+++ b/.jules/exchange/events/platform_fallback_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2026-03-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Critical OS/Architecture fallback and parsing logic in `src/domain/platform.ts` lacks test coverage, risking subtle installation failures on edge-case hardware.
+
+## Goal
+
+Improve branch and line coverage for platform detection (`detectPlatformTuple`), specifically targeting the Rosetta ARM64 fallback and OS/Arch normalization failures.
+
+## Context
+
+Platform detection determines which binary asset to download or build. `src/domain/platform.ts` has low line coverage (28.3%) and poor function coverage (20%). The uncovered lines (12-20, 37-69) correspond to the Rosetta detection logic (`detectRosettaArm64`), and the switch statement fallbacks for unsupported OS (`normalizeOs`) and architecture (`normalizeArch`). This logic is a critical decision point for successful `jlo` installation on diverse runner architectures (like Apple Silicon vs Intel Macs). If this logic silently breaks or regresses, it will lead to download errors for the wrong binary or cryptic execution failures.
+
+## Evidence
+
+- path: "src/domain/platform.ts"
+  loc: "Lines 37-69"
+  note: "Uncovered switch statement defaults in `normalizeOs` and `normalizeArch`. Missing tests for unsupported OS/arch throws."
+- path: "src/domain/platform.ts"
+  loc: "Lines 12-20"
+  note: "Uncovered `detectRosettaArm64` fallback logic which executes `sysctl`. This is a critical branch for Darwin X86_64 to Aarch64 resolution."
+
+## Change Scope
+
+- `src/domain/platform.ts`
+- `tests/domain/platform.test.ts`


### PR DESCRIPTION
Added three high-signal event files regarding critical test coverage risks as requested for the `cov` role. The events highlight missing coverage in authentication failure paths, platform fallback logic, and core application flows (download/build failure modes). All changes are confined to the `.jules/exchange/events/` directory and comply with the required schema.

---
*PR created automatically by Jules for task [9817073320471448251](https://jules.google.com/task/9817073320471448251) started by @akitorahayashi*