### PR TITLE
Add typescripter events for JSON casting and error coercion

### DIFF
--- a/.jules/exchange/events/unsafe_error_coercion_typescripter.md
+++ b/.jules/exchange/events/unsafe_error_coercion_typescripter.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2024-03-20"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Errors caught in `catch` blocks are unsafely coerced using `as Error`, ignoring the fact that JavaScript can throw any value (e.g., strings, null, undefined).
+
+## Goal
+
+Properly handle `unknown` errors in `catch` blocks by checking if the caught object is an instance of `Error` before accessing its properties like `.message`, instead of blindly casting it.
+
+## Context
+
+In TypeScript, caught errors are of type `unknown` by default because any value can be thrown. Using `as Error` forces the compiler to treat the value as an `Error` object. If a string or a plain object is thrown, accessing `.message` on it will result in `undefined`, potentially leading to unhelpful error messages or further runtime issues. A safer approach is to use `error instanceof Error` or a utility function to reliably extract a message from an `unknown` error type.
+
+## Evidence
+
+- path: "src/app/install-main-source.ts"
+  loc: "line 72"
+  note: "Inside the `catch` block for `updateGitHubSubmodules`, the error is formatted into a string by calling `(error as Error).message` without verifying if `error` actually has a `message` property."
+
+## Change Scope
+
+- `src/app/install-main-source.ts`

--- a/.jules/exchange/events/unvalidated_http_json_typescripter.md
+++ b/.jules/exchange/events/unvalidated_http_json_typescripter.md
@@ -1,0 +1,33 @@
+---
+label: "bugs"
+created_at: "2024-03-20"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+External HTTP JSON responses are blindly trusted and cast with `as Type`, circumventing the TypeScript type system's ability to guarantee runtime safety.
+
+## Goal
+
+Validate untrusted external JSON data at the boundary using a schema validator (like Zod) or type guards before allowing it into the typed core of the application, replacing unsafe `as Type` assertions.
+
+## Context
+
+TypeScript types are erased at runtime. When fetching data from an external API, using `as Type` on the JSON response provides a false sense of security (type illusion). If the API changes or returns unexpected data, the application will fail unpredictably later rather than failing fast at the boundary where the untrusted data enters. This violates the principle of validating external inputs before trusting types.
+
+## Evidence
+
+- path: "src/adapters/github/release-asset-api.ts"
+  loc: "line 36"
+  note: "The response from `https://api.github.com/repos/${owner}/${repo}/releases/tags/${options.tagVersion}` is parsed using `await metadataResponse.json()` and immediately cast using `as { assets?: Array<{ id: number; name: string }> }` without any runtime validation."
+
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "line 29"
+  note: "The response from `GITHUB_API_USER_URL` is parsed using `await response.json()` and immediately cast using `as { login?: string; type?: string }` without any runtime validation."
+
+## Change Scope
+
+- `src/adapters/github/release-asset-api.ts`
+- `src/adapters/github/github-git-http-username.ts`


### PR DESCRIPTION
Added two typescripter events to `.jules/exchange/events`:

1.  `unvalidated_http_json_typescripter.md`: Flags the unsafe `as Type` casting of external HTTP JSON responses in `src/adapters/github/release-asset-api.ts` and `src/adapters/github/github-git-http-username.ts`.
2.  `unsafe_error_coercion_typescripter.md`: Flags the unsafe `as Error` coercion of caught `unknown` errors in `src/app/install-main-source.ts`.

Both events include concrete file-level evidence and adhere to the project's formatting constraints (e.g., no bold text).

---
*PR created automatically by Jules for task [7795092924759319183](https://jules.google.com/task/7795092924759319183) started by @akitorahayashi*