### PR TITLE
docs(taxonomy): emit observer event files for naming consistency

### DIFF
--- a/.jules/exchange/events/token_naming_taxonomy.md
+++ b/.jules/exchange/events/token_naming_taxonomy.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-05-20"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The internal naming of GitHub tokens in `InstallRequest` (`installToken`, `installSubmoduleToken`) diverges from the public input names (`token`, `submodule_token`). The prefix `install` implies a specific lifecycle phase, but `token` is just an access token used across all phases (metadata fetch, download, clone).
+
+## Goal
+
+Align internal token property names in `InstallRequest` with the public input names (`token`, `submoduleToken`), removing the unnecessary `install` prefix that incorrectly scopes their purpose.
+
+## Context
+
+In `action.yml`, the inputs are `token` and `submodule_token`. In `src/action/install-request.ts`, these are mapped to `installToken` and `installSubmoduleToken`. The "install" prefix adds no clarity since everything happens within an "install" action, and it diverges from standard GitHub action conventions where internal properties mirror input names.
+
+## Evidence
+
+- path: "src/action/install-request.ts"
+  loc: "lines 2-3, 16-17"
+  note: "Defines `installToken` and `installSubmoduleToken` properties."
+- path: "action.yml"
+  loc: "lines 4, 10"
+  note: "Defines the inputs simply as `token` and `submodule_token`."
+
+## Change Scope
+
+- `src/action/install-request.ts`
+- `src/app/install-main-source.ts`
+- `src/app/install-release.ts`
+- `tests/action/install-request.test.ts`

--- a/.jules/exchange/events/version_token_taxonomy.md
+++ b/.jules/exchange/events/version_token_taxonomy.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2024-05-20"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The concept of "version token" and "install mode" is inconsistent. The input `version` refers to a version token, but the output `install-mode` uses `release-tag` while the internal representation `ParsedVersionToken.kind` uses `release`. The `version-token` output has a hyphen, while `version` does not.
+
+## Goal
+
+Align the terminology for version/install modes across the codebase, specifically aligning `release` and `release-tag`.
+
+## Context
+
+The codebase uses `release` as the internal kind for a parsed version token in `src/domain/version-token.ts` but the public `install-mode` output exposes `release-tag`. `src/index.ts` has a specific mapping for this (`parsedVersion.kind === 'release' ? 'release-tag' : 'main'`). `action.yml` uses `release-tag`. This creates a conceptual divergence between the domain layer and the action output layer.
+
+## Evidence
+
+- path: "src/domain/version-token.ts"
+  loc: "line 2"
+  note: "Defines the internal kind as `release`."
+- path: "src/index.ts"
+  loc: "line 19"
+  note: "Explicitly maps `release` to `release-tag` for the install mode."
+- path: "action.yml"
+  loc: "line 15"
+  note: "Documents `release-tag` as the resolved installation mode."
+
+## Change Scope
+
+- `src/domain/version-token.ts`
+- `src/index.ts`
+- `src/action/outputs.ts`
+- `action.yml`
+- `docs/configuration/inputs.md`
+- `docs/usage.md`

--- a/.jules/exchange/events/version_variable_taxonomy.md
+++ b/.jules/exchange/events/version_variable_taxonomy.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-05-20"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+In `src/index.ts`, `resolveInstallMode` uses `token` as the parameter name for the version input, while `run()` uses `versionToken` for the same concept. Furthermore, `token` in `run()` refers to the GitHub token (`readRequiredInput('token')`). This overloads the word "token" within the same file for two entirely different concepts (a GitHub API token vs a version string).
+
+## Goal
+
+Standardize the naming for the "version token" concept to consistently use `versionToken` or `versionInput` throughout `src/index.ts`, ensuring it is not confused with the GitHub `token` input.
+
+## Context
+
+The word "token" is overloaded. The `token` action input represents a GitHub personal access token or `GITHUB_TOKEN`. The `version` action input represents what the docs and code call a "version token" (e.g. `23.0.0` or `main`). Using `token` to refer to both in the same file hurts readability and refactor safety.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "line 8"
+  note: "`export function resolveInstallMode(token: string)` uses `token` for the version."
+- path: "src/index.ts"
+  loc: "line 14"
+  note: "`const token = readRequiredInput('token')` uses `token` for the GitHub token."
+- path: "src/index.ts"
+  loc: "line 15"
+  note: "`const versionToken = readRequiredInput('version')` uses `versionToken` for the version."
+
+## Change Scope
+
+- `src/index.ts`


### PR DESCRIPTION
I've investigated the codebase under the taxonomy observer role and emitted three high-signal event findings regarding naming inconsistencies, primarily dealing with how "tokens", "versions", and "install modes" are referred to internally versus their public inputs/outputs.

---
*PR created automatically by Jules for task [7081574416998157233](https://jules.google.com/task/7081574416998157233) started by @akitorahayashi*