### PR TITLE
docs: emit consistency events for architecture documentation drift

### DIFF
--- a/.jules/exchange/events/dependency_direction_drift_consistency.md
+++ b/.jules/exchange/events/dependency_direction_drift_consistency.md
@@ -1,0 +1,40 @@
+---
+label: "docs"
+created_at: "2024-03-20"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation in `docs/architecture.md` incorrectly documents the dependency direction. `action -> domain` is specified but no files in `src/action` import from `src/domain`. In contrast, files in `src/app` import from `src/action`.
+
+## Goal
+
+Update the dependency direction in `docs/architecture.md` to accurately reflect the actual import relationships between the runtime boundaries.
+
+## Context
+
+The architecture documentation explicitly models dependency direction to enforce purity and layering. Specifically, it lists `action -> domain` but code grep confirms `src/action` does not import from `src/domain`. Additionally, the file `src/app/install-main-source.ts` and `src/app/install-release.ts` both import `InstallRequest` from `src/action/install-request.ts`.
+
+## Evidence
+
+- path: "docs/architecture.md"
+  loc: "32"
+  note: "Documents `action -> domain`, which is incorrect based on `src/action` imports."
+
+- path: "src/action"
+  loc: "directory"
+  note: "Files inside `src/action/` do not import anything from `src/domain/`."
+
+- path: "src/app/install-main-source.ts"
+  loc: "4"
+  note: "Imports `InstallRequest` from `../action/install-request.ts`, which indicates an `app -> action` dependency not documented in `docs/architecture.md`."
+
+- path: "src/app/install-release.ts"
+  loc: "8"
+  note: "Imports `InstallRequest` from `../action/install-request.ts`, supporting the `app -> action` dependency."
+
+## Change Scope
+
+- `docs/architecture.md`

--- a/.jules/exchange/events/missing_tests_adapters_documentation_drift_consistency.md
+++ b/.jules/exchange/events/missing_tests_adapters_documentation_drift_consistency.md
@@ -1,0 +1,32 @@
+---
+label: "docs"
+created_at: "2024-03-20"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation in `docs/architecture.md` incorrectly omits the `tests/adapters` directory from its list of repository-owned boundary tests, despite the implementation containing a `tests/adapters` directory with tests.
+
+## Goal
+
+Update the documentation to accurately reflect the current testing boundaries, including `tests/adapters`.
+
+## Context
+
+`docs/architecture.md` outlines the test directories as `tests/action`, `tests/app`, and `tests/domain`. However, a `tests/adapters` directory exists in the codebase and contains boundary tests (e.g., `tests/adapters/github-git-http-username.test.ts`). The documentation should serve as a source of truth for the codebase's current structure.
+
+## Evidence
+
+- path: "docs/architecture.md"
+  loc: "12, 80"
+  note: "Mentions `tests/` contains boundary tests under `tests/action`, `tests/app`, and `tests/domain`, omitting `tests/adapters`."
+
+- path: "tests/adapters"
+  loc: "directory"
+  note: "Directory exists and contains tests such as `github-git-http-username.test.ts`."
+
+## Change Scope
+
+- `docs/architecture.md`


### PR DESCRIPTION
Emits 2 high-signal consistency events documenting architectural drift between the actual implementation and what is written in `docs/architecture.md`. These findings highlight incorrect dependency direction documentation and missing boundary test directory coverage.

---
*PR created automatically by Jules for task [15201440391541894358](https://jules.google.com/task/15201440391541894358) started by @akitorahayashi*