### PR TITLE
docs: fix architecture doc to reflect app -> action dependency and include adapters test directory

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,8 @@ The runtime boundaries are:
 Runtime dependencies follow this direction:
 
 ```text
-index -> action -> app -> domain
+index -> app -> domain
+index -> action
 app -> action
 app -> adapters
 app -> catalog


### PR DESCRIPTION
1. Updated docs/architecture.md dependency direction section from `action -> domain` to `app -> action`.
2. Updated docs/architecture.md test boundaries to include `tests/adapters`.

---
*PR created automatically by Jules for task [129279283296597419](https://jules.google.com/task/129279283296597419) started by @akitorahayashi*