### PR TITLE
Create observer drift events for submodule token documentation and README link index violation

### DIFF
--- a/.jules/exchange/events/documentation_links_drift_consistency.md
+++ b/.jules/exchange/events/documentation_links_drift_consistency.md
@@ -1,0 +1,36 @@
+---
+label: "docs"
+created_at: "2024-05-24"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+`README.md` bypasses `docs/README.md` as the sole index for documentation by linking directly to `docs/usage.md` and `docs/architecture.md`.
+
+## Goal
+
+Ensure `README.md` treats `docs/README.md` as the single authoritative index for documentation, routing all documentation references through it rather than linking to individual subpages directly.
+
+## Context
+
+The repository memory explicitly states: "The documentation structure requires `./README.md` as the public front door, `./CONTRIBUTING.md` for workflows, and `docs/README.md` as the sole index for `docs/`." Currently, `README.md` links to `docs/usage.md` and `docs/architecture.md` directly. While these paths are technically correct, this violates the principle of `docs/README.md` being the sole index. If users go directly to the subpages from `README.md`, the index is bypassed.
+
+## Evidence
+
+- path: "README.md"
+  loc: "19-20"
+  note: "Links directly to `[docs/usage.md](docs/usage.md)`."
+
+- path: "README.md"
+  loc: "25-26"
+  note: "Links directly to `[docs/architecture.md](docs/architecture.md)`."
+
+- path: "README.md"
+  loc: "31-32"
+  note: "Links to `[docs/README.md](docs/README.md)` only for Configuration."
+
+## Change Scope
+
+- `README.md`

--- a/.jules/exchange/events/submodule_token_required_drift_consistency.md
+++ b/.jules/exchange/events/submodule_token_required_drift_consistency.md
@@ -1,0 +1,41 @@
+---
+label: "docs"
+created_at: "2024-05-24"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+Documentation in `docs/configuration/inputs.md` and `action.yml` states that `submodule_token` is not required, but the implementation strictly requires it for `main` install mode.
+
+## Goal
+
+Align the documentation to accurately reflect the implementation's requirement that `submodule_token` must be provided when `version` is set to `main`, or adjust the implementation/action contract if the intent is for it to be optional.
+
+## Context
+
+In `action.yml` and `docs/configuration/inputs.md`, `submodule_token` is listed as optional/not required. However, in `src/app/install-main-source.ts`, the implementation throws an error: `"main install requires submodule_token."` if it is not provided. While it's only required for `main` mode, documenting it globally as `required: false` without clear conditional requirement notes in the tables leads to confusion, and `docs/configuration/access.md` explicitly states it *is* required for `main` mode, creating contradictory documentation.
+
+## Evidence
+
+- path: "action.yml"
+  loc: "12"
+  note: "Lists `submodule_token` with `required: false`."
+
+- path: "docs/configuration/inputs.md"
+  loc: "11"
+  note: "Table lists `submodule_token` Required as `no`."
+
+- path: "docs/configuration/access.md"
+  loc: "21"
+  note: "States `submodule_token` is required for `main` mode."
+
+- path: "src/app/install-main-source.ts"
+  loc: "37-39"
+  note: "Throws error if `request.submoduleToken` is not provided."
+
+## Change Scope
+
+- `action.yml`
+- `docs/configuration/inputs.md`


### PR DESCRIPTION
Created observer events detailing inconsistencies in the documentation around `submodule_token` requirements and links violating index structure.

---
*PR created automatically by Jules for task [18400646543975162533](https://jules.google.com/task/18400646543975162533) started by @akitorahayashi*