### PR TITLE
Generate coverage events for missing critical paths

### DIFF
--- a/.jules/exchange/events/uncovered_github_api_metadata_cov.md
+++ b/.jules/exchange/events/uncovered_github_api_metadata_cov.md
@@ -1,0 +1,34 @@
+---
+label: "tests"
+created_at: "2024-05-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Coverage gaps in GitHub API validation utilities mask edge-case vulnerabilities where the API returns unexpected data structures, specifically non-objects or unexpectedly typed primitives.
+
+## Goal
+
+Add tests to ensure `isGitHubUser` and `isReleaseMetadata` correctly reject unexpected payloads (like strings instead of objects or mis-typed properties).
+
+## Context
+
+Lines 8-9 and 18-19 in `src/adapters/github/github-git-http-username.ts` (`typeof data !== 'object' || data === null` and `typeof obj.type !== 'string'`) and lines 7-8, 13-14, 20-21 in `src/adapters/github/release-asset-api.ts` indicate missing coverage for type guard checks when external APIs return wildly unexpected formats. If the GitHub API changes or returns an unexpected response, it might cause type casting errors downstream instead of being cleanly rejected by these utilities.
+
+## Evidence
+
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "8-9, 18-19"
+  note: "Branches handling `data === null`, `typeof data !== 'object'`, and `typeof obj.type !== 'string'` are untested."
+- path: "src/adapters/github/release-asset-api.ts"
+  loc: "7-8, 13-14, 20-21"
+  note: "Branches handling unexpected non-object payloads, undefined `assets`, or array elements that are not objects are not tested."
+
+## Change Scope
+
+- `src/adapters/github/github-git-http-username.ts`
+- `src/adapters/github/release-asset-api.ts`
+- `tests/adapters/github/github-git-http-username.test.ts`
+- `tests/adapters/github/release-asset-api.test.ts`

--- a/.jules/exchange/events/uncovered_install_source_commands_cov.md
+++ b/.jules/exchange/events/uncovered_install_source_commands_cov.md
@@ -1,0 +1,34 @@
+---
+label: "tests"
+created_at: "2024-05-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The logic checking for missing `cargo` and `git` binaries on `installMainSource` and `installReleaseVersion` branches is missing test coverage.
+
+## Goal
+
+Add tests to ensure `installMainSource` and `installReleaseVersion` fail fast and clearly when required build dependencies (cargo, git) or extraction tools are not available on the runner.
+
+## Context
+
+Coverage tests show missing line coverage in `src/app/install-main-source.ts` lines 28-31, 33-34, and `src/app/install-release.ts` lines 76-79. These specific areas handle throwing errors when `cargo` or `git` are missing. Without these tests, a regression might accidentally swallow missing command errors, leading to obscure failures later in the GitHub Action run.
+
+## Evidence
+
+- path: "src/app/install-main-source.ts"
+  loc: "28-31, 33-34"
+  note: "Branches handling missing `cargo` or `git` commands lack tests."
+- path: "src/app/install-release.ts"
+  loc: "76-79"
+  note: "These lines are related to the final steps of `installReleaseVersion` including pruning sibling install directories and installing the binary on path, but they are not executed in tests."
+
+## Change Scope
+
+- `src/app/install-main-source.ts`
+- `tests/app/install-main-source.test.ts`
+- `src/app/install-release.ts`
+- `tests/app/install-release.test.ts`


### PR DESCRIPTION
I have completed my analysis of the `setup-jlo` repository as the `cov` observer. I have generated two high-signal event files within the `.jules/exchange/events/` directory detailing missing critical path coverage to ensure we detect regressions effectively. I also reverted initial dependency adjustments to ensure I adhered to the restriction against modifying files outside `.jules/exchange/`.

---
*PR created automatically by Jules for task [12803499135274774168](https://jules.google.com/task/12803499135274774168) started by @akitorahayashi*