### PR TITLE
Emit Data Architecture Observer Events

### DIFF
--- a/.jules/exchange/events/inconsistent_repository_slug_usage_data_arch.md
+++ b/.jules/exchange/events/inconsistent_repository_slug_usage_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-21"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The domain type `RepositorySlug` exists to represent an owner and repository tuple. However, this type is bypassed in `src/adapters/process/github-source-git.ts`, where repository slugs are manipulated as raw strings. The function `buildGitHubRepositoryUrl` and its callers simply concatenate `options.repository`, missing the data validation guarantees of `parseRepositorySlug`.
+
+## Goal
+
+Ensure `RepositorySlug` is the single source of truth for representing repository identities by leveraging `parseRepositorySlug` at the boundary entry points to enforce invariants.
+
+## Context
+
+Passing around raw strings instead of validated domain objects allows invalid states to be represented (e.g., an un-namespaced repository string) and bypasses boundary validation. This violates the principle of "Represent Valid States Only", meaning invariants should be encoded such that invalid states are hard to express. It's missing validation that is present elsewhere in the system.
+
+## Evidence
+
+- path: "src/domain/repository-slug.ts"
+  loc: "line 1-20"
+  note: "Defines `RepositorySlug` and validation logic via `parseRepositorySlug`."
+- path: "src/adapters/process/github-source-git.ts"
+  loc: "line 16, 31, 134, 139, 140"
+  note: "Accepts `repository` as a raw `string` and concatenates it without any validation, rather than accepting or parsing a `RepositorySlug`."
+
+## Change Scope
+
+- `src/adapters/process/github-source-git.ts`
+- `src/app/install-main-source.ts`

--- a/.jules/exchange/events/version_token_semantic_overload_data_arch.md
+++ b/.jules/exchange/events/version_token_semantic_overload_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-21"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The term `token` is overloaded in the codebase. It refers to both the installation version requested by the user (`versionToken`) and the GitHub API authentication token (`token` / `submoduleToken`). The `ParsedVersionToken` type has a variant `{ kind: 'main'; token: 'main' }` which reuses the word `token` for a completely different concept than authentication.
+
+## Goal
+
+Disambiguate the term `token` across the codebase. Ensure `token` strictly means an authentication token, and use a term like `version` or `ref` for installation targets to avoid semantic overlap.
+
+## Context
+
+Using the same term for conceptually different facts violates the First Principle of Boundary Sovereignty and Single Source of Truth, as the meaning of `token` depends heavily on context. The memory guidelines explicitly state: "In the setup-jlo codebase, 'versionToken' refers to the installation version requested by the user, while 'token' specifically refers to the GitHub API authentication token. Do not overload these variable names." Re-using `token` within `ParsedVersionToken` for the `'main'` literal introduces an invalid state of ambiguity.
+
+## Evidence
+
+- path: "src/domain/version-token.ts"
+  loc: "line 3"
+  note: "Defines the 'main' variant as `{ kind: 'main'; token: 'main' }` instead of `{ kind: 'main'; version: 'main' }` or similar, overloading the term 'token'."
+- path: "src/action/install-request.ts"
+  loc: "line 5, 13, 40"
+  note: "Uses 'token' and 'submoduleToken' for GitHub authentication credentials."
+
+## Change Scope
+
+- `src/domain/version-token.ts`
+- `src/index.ts`


### PR DESCRIPTION
Emits observer events based on data architecture findings:
1. Identified semantic overload of the `token` variable, where it is used both for authentication credentials and the parsed installation target literal `'main'`.
2. Identified inconsistent usage of the `RepositorySlug` domain type, pointing out that `src/adapters/process/github-source-git.ts` bypasses boundary validations by passing repository identifiers as raw strings.

---
*PR created automatically by Jules for task [3734564953804154484](https://jules.google.com/task/3734564953804154484) started by @akitorahayashi*