### PR TITLE
Emit QA observer events on test quality and structure

### DIFF
--- a/.jules/exchange/events/brittle_cache_adapter_tests_qa.md
+++ b/.jules/exchange/events/brittle_cache_adapter_tests_qa.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "qa"
+confidence: "medium"
+---
+
+## Problem
+
+The cache adapter tests mock `node:fs` and `node:child_process` heavily to verify cache directory structures and binary version output, tightly coupling to system paths and spawn signatures.
+
+## Goal
+
+To test caching behavior effectively without high maintenance cost, we should use an in-memory or actual temporary filesystem for testing the cache adapter. Mocks should only be used for strict process execution boundaries (`spawnSync` of the binary) rather than all generic filesystem operations.
+
+## Context
+
+Mocking `node:fs` globally can lead to tests that pass but fail in reality due to subtle API mismatches. Using actual temporary directories (like `node:os` tempdir) and `fs` operations allows validating the correct creation, deletion, and permission assignments of files.
+
+## Evidence
+
+- path: "tests/adapters/cache/binary-install-cache.test.ts"
+  loc: "line 15"
+  note: "Uses `vi.mock('node:fs')` which mocks all filesystem operations, missing real integration bugs."
+
+## Change Scope
+
+- `tests/adapters/cache/binary-install-cache.test.ts`

--- a/.jules/exchange/events/global_mutation_in_platform_tests_qa.md
+++ b/.jules/exchange/events/global_mutation_in_platform_tests_qa.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test file `tests/domain/platform.test.ts` mutates global `process` properties (`process.platform` and `process.arch`) during tests without complete isolation guarantees across async/parallel executions.
+
+## Goal
+
+Ensure isolated testing without mutating global state. Use dependency injection to pass the `platform` and `arch` as parameters to `detectPlatformTuple`, or use a dedicated mocking strategy that completely isolates the environment per test execution.
+
+## Context
+
+Modifying global state in tests is a known anti-pattern ("Isolation By Design: avoid shared mutable state"). While `beforeEach` and `afterEach` try to clean it up, this can still cause non-determinism and flakiness if tests run in parallel or if a test fails unexpectedly and doesn't reach the teardown phase correctly in certain testing frameworks.
+
+## Evidence
+
+- path: "tests/domain/platform.test.ts"
+  loc: "line 26"
+  note: "The `mockProcess` function explicitly redefines `process.platform` and `process.arch` properties."
+
+## Change Scope
+
+- `src/domain/platform.ts`
+- `tests/domain/platform.test.ts`

--- a/.jules/exchange/events/over_coupled_orchestration_tests_qa.md
+++ b/.jules/exchange/events/over_coupled_orchestration_tests_qa.md
@@ -1,0 +1,33 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Application orchestration tests are over-coupled to internal implementation details, mocking up to 18 individual dependencies per file. This makes the tests extremely brittle and tightly bound to the current implementation structure, defeating their purpose as behavior verifiers.
+
+## Goal
+
+Refactor the orchestration boundaries to reduce mocking. Tests should validate externally visible behavior using fakes or by observing the boundary of side effects (I/O, network, process execution) rather than mocking every internal function call.
+
+## Context
+
+The `installMainSource` and `installReleaseVersion` tests mock large numbers of `node:fs`, `node:os`, domain functions, and adapter functions. This is a recognized anti-pattern ("Over-coupling tests to private implementation details") as any minor refactor in the dependencies or their usage will break the tests, reducing recovery cost optimization and increasing maintenance overhead.
+
+## Evidence
+
+- path: "tests/app/install-main-source.test.ts"
+  loc: "line 4"
+  note: "Mocks 18 internal dependencies including standard library functions (`existsSync`, `mkdtempSync`) and custom adapters (`cloneGitHubBranch`, `detectPlatformTuple`, etc.)"
+
+- path: "tests/app/install-release.test.ts"
+  loc: "line 4"
+  note: "Mocks 17 internal dependencies, heavily coupling the test to the implementation details instead of testing external behavior."
+
+## Change Scope
+
+- `tests/app/install-main-source.test.ts`
+- `tests/app/install-release.test.ts`


### PR DESCRIPTION
This PR adds three high-signal QA event files to `.jules/exchange/events/` documenting:

1.  **Over-coupled orchestration tests:** Tests in `tests/app/` mock an excessive number of internal dependencies, making them brittle and failing to validate externally visible behavior effectively.
2.  **Global state mutation in platform tests:** `tests/domain/platform.test.ts` mutates global `process.platform` and `process.arch`, causing potential non-determinism during parallel execution.
3.  **Brittle cache adapter tests:** Tests in `tests/adapters/cache/binary-install-cache.test.ts` over-mock generic `node:fs` APIs instead of using a temporary filesystem for true boundary verification.

---
*PR created automatically by Jules for task [10305452610586390820](https://jules.google.com/task/10305452610586390820) started by @akitorahayashi*