### PR TITLE
Emit taxonomy observation events for naming inconsistencies

### DIFF
--- a/.jules/exchange/events/repository_slug_naming_taxonomy.md
+++ b/.jules/exchange/events/repository_slug_naming_taxonomy.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2025-03-23"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The concept of a GitHub repository specified as an `<owner>/<repo>` string is inconsistently named across the application boundaries, alternating between `slug`, `repository`, and `releaseRepository`.
+
+## Goal
+
+Establish a canonical naming convention for `<owner>/<repo>` string identifiers (e.g., `repository_slug`) and standardize it across all modules to ensure consistent parameter names and domain terminology.
+
+## Context
+
+Different layers use different terms for the exact same conceptual parameter. `parseRepositorySlug` accepts a `slug`, while `cloneGitHubBranch` accepts `repository`, and `fetchReleaseAsset` specifically names it `releaseRepository`. This inconsistency requires developers to mentally map synonymous terms across the domain, app, and adapter boundaries.
+
+## Evidence
+
+- path: "src/domain/repository-slug.ts"
+  loc: "export function parseRepositorySlug(slug: string)"
+  note: "Domain module explicitly introduces the term 'slug'."
+- path: "src/adapters/process/github-source-git.ts"
+  loc: "export function cloneGitHubBranch(options: { repository: string, ... })"
+  note: "Process adapter uses 'repository' for the identical concept."
+- path: "src/adapters/github/release-asset-api.ts"
+  loc: "export async function fetchReleaseAsset(options: { releaseRepository: string, ... })"
+  note: "API adapter introduces 'releaseRepository'."
+
+## Change Scope
+
+- `src/domain/repository-slug.ts`
+- `src/adapters/process/github-source-git.ts`
+- `src/adapters/github/release-asset-api.ts`
+- `src/app/install-main-source.ts`
+- `src/app/install-release.ts`

--- a/.jules/exchange/events/token_concept_overload_taxonomy.md
+++ b/.jules/exchange/events/token_concept_overload_taxonomy.md
@@ -1,0 +1,40 @@
+---
+label: "refacts"
+created_at: "2025-03-23"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The term "token" is heavily overloaded across the repository, simultaneously representing both a GitHub authentication credential (e.g., `token`, `submodule_token`) and an installation target identifier or parsed version (e.g., `version-token`, `ParsedVersionToken`).
+
+## Goal
+
+Establish distinct and mutually exclusive terminology for authentication credentials (e.g., `credential`, `auth_token`, `secret`) versus installation identifiers (e.g., `version_specifier`, `install_target`, `version_string`).
+
+## Context
+
+Using the same noun for two entirely distinct domain concepts leads to ambiguity, especially in function signatures or variable lists where the purpose of `token` must be inferred from context rather than the type or name. The codebase uses `version-token` (action outputs), `token` (auth input), `submodule_token` (auth input), and `ParsedVersionToken` (domain model), creating a confusing shared vocabulary that increases cognitive load for newcomers.
+
+## Evidence
+
+- path: "action.yml"
+  loc: "inputs.token, outputs.version-token"
+  note: "Action input 'token' refers to an authentication credential, while the output is 'version-token'."
+- path: "src/domain/version-token.ts"
+  loc: "type ParsedVersionToken, parseVersionToken()"
+  note: "The domain uses 'token' to refer to the unparsed version specifier, such as a semver string or 'main'."
+- path: "src/action/install-request.ts"
+  loc: "interface InstallRequest { token: string; submoduleToken?: string; }"
+  note: "The action layer uses 'token' and 'submoduleToken' exclusively as authentication strings for API requests and Git cloning."
+
+## Change Scope
+
+- `action.yml`
+- `src/domain/version-token.ts`
+- `src/action/install-request.ts`
+- `src/index.ts`
+- `src/adapters/process/github-source-git.ts`
+- `src/adapters/github/release-asset-api.ts`
+- `src/adapters/github/github-git-http-username.ts`


### PR DESCRIPTION
This commit emits two taxonomy events identifying high-signal naming inconsistencies in the repository:
1. `repository_slug_naming_taxonomy.md`: Documents the inconsistent use of `slug`, `repository`, and `releaseRepository` for the `<owner>/<repo>` string concept.
2. `token_concept_overload_taxonomy.md`: Documents the overloading of the term "token", which is used both as an authentication credential and a version identifier.

---
*PR created automatically by Jules for task [6412353275987841022](https://jules.google.com/task/6412353275987841022) started by @akitorahayashi*