### PR TITLE
Add data architecture observer events

### DIFF
--- a/.jules/exchange/events/duplicate_version_parsing_data_arch.md
+++ b/.jules/exchange/events/duplicate_version_parsing_data_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-03-23"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The logic for extracting semantic versions from string output is duplicated across `src/domain/version-token.ts` and `src/adapters/cache/binary-install-cache.ts`. The `binary-install-cache` has its own local `extractFirstSemverTriplet` function that calls `extractSemver` internally.
+
+## Goal
+
+Unify the extraction and parsing of semver strings under the domain logic (`version-token.ts`), rather than leaving a pseudo-parsing utility inside the caching adapter.
+
+## Context
+
+The `binary-install-cache.ts` acts as an adapter, but it includes domain-level logic to extract versions by splitting strings (`extractFirstSemverTriplet`). This violates "Single Source of Truth", as the caching adapter is taking on the responsibility of identifying a valid version string format.
+
+## Evidence
+
+- path: "src/domain/version-token.ts"
+  loc: "line 15-21"
+  note: "`extractSemver` performs string normalization and regex matching to detect a semver core."
+
+- path: "src/adapters/cache/binary-install-cache.ts"
+  loc: "line 84-92"
+  note: "`extractFirstSemverTriplet` loops over string tokens and uses `extractSemver` to find the first valid version, an action that belongs in the domain boundary rather than an adapter."
+
+## Change Scope
+
+- `src/domain/version-token.ts`
+- `src/adapters/cache/binary-install-cache.ts`

--- a/.jules/exchange/events/monolithic_install_request_data_arch.md
+++ b/.jules/exchange/events/monolithic_install_request_data_arch.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2024-03-23"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The `InstallRequest` interface in `src/action/install-request.ts` acts as a monolithic container coupling properties for distinct operational modes. Specifically, `submoduleToken` is only relevant for the `main` install mode, while `allowDarwinX8664Fallback` is primarily a concern for the `release-tag` install mode. This forces invalid state representations (e.g. `submoduleToken?: string`) that are checked ad-hoc downstream.
+
+## Goal
+
+Model distinct input structures for `main` vs. `release-tag` installations. This ensures that the type system guarantees the presence of required parameters (like `submoduleToken` for source builds) at the boundary, adhering to "Represent Valid States Only".
+
+## Context
+
+Using an optional `submoduleToken` leads to implicit validation or panics deep in the application logic (`src/app/install-main-source.ts:37`), violating "Where are invariants enforced: boundaries (preferred) or scattered call sites?". A tagged union or separate request types based on the resolved `InstallMode` would guarantee that when a `main` build is requested, its required configuration is statically guaranteed.
+
+## Evidence
+
+- path: "src/action/install-request.ts"
+  loc: "line 6"
+  note: "`submoduleToken` is defined as optional `submoduleToken?: string` in the unified `InstallRequest`."
+
+- path: "src/app/install-main-source.ts"
+  loc: "line 37-39"
+  note: "Scatter validation: `if (!request.submoduleToken) { throw new Error(...) }` checks for the token at the usage site rather than enforcing it at the action boundary."
+
+- path: "src/action/install-request.ts"
+  loc: "line 7"
+  note: "`allowDarwinX8664Fallback` is present on all requests, though only `installReleaseVersion` consumes it."
+
+## Change Scope
+
+- `src/action/install-request.ts`
+- `src/index.ts`
+- `src/app/install-main-source.ts`
+- `src/app/install-release.ts`

--- a/.jules/exchange/events/primitive_obsession_repository_slug_data_arch.md
+++ b/.jules/exchange/events/primitive_obsession_repository_slug_data_arch.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2024-03-23"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The `RepositorySlug` interface is defined in `src/domain/repository-slug.ts`, but it is not used consistently across the codebase. For example, `src/catalog/jlo.ts` defines `JLO_REPOSITORY` as a plain string (`'asterismhq/jlo'`). This primitive obsession leaks transport/UI concerns into core logic and forces call sites to parse the string back into a `RepositorySlug` object or concatenate strings manually.
+
+## Goal
+
+Enforce the single source of truth for repository identifiers by using the `RepositorySlug` domain type directly in the catalog and across boundaries, eliminating string parsing at call sites.
+
+## Context
+
+Using plain strings for structured domain concepts violates "Boundary Sovereignty" and "Single Source of Truth." It requires manual parsing or formatting at points of use (e.g., in `fetchReleaseAsset`), increasing the risk of invalid formats being passed deep into the system. Representing the catalog entry as a valid `RepositorySlug` object directly encodes invariants at the source.
+
+## Evidence
+
+- path: "src/catalog/jlo.ts"
+  loc: "line 1"
+  note: "`JLO_REPOSITORY` is defined as a plain string `'asterismhq/jlo'` instead of a `RepositorySlug`."
+
+- path: "src/adapters/github/release-asset-api.ts"
+  loc: "line 29"
+  note: "`fetchReleaseAsset` accepts `releaseRepository: string` and immediately parses it into a `RepositorySlug` (`const { owner, repo } = parseRepositorySlug(options.releaseRepository)`)."
+
+- path: "src/adapters/process/github-source-git.ts"
+  loc: "line 117"
+  note: "`cloneGitHubBranch` accepts `repository: string` and concatenates it manually in `buildGitHubRepositoryUrl`."
+
+## Change Scope
+
+- `src/catalog/jlo.ts`
+- `src/domain/repository-slug.ts`
+- `src/adapters/github/release-asset-api.ts`
+- `src/adapters/process/github-source-git.ts`


### PR DESCRIPTION
I've added 3 new high-signal data architecture observer events as requested:
1. `duplicate_version_parsing_data_arch.md`: Points out duplicate semver parsing logic between `src/domain/version-token.ts` and `src/adapters/cache/binary-install-cache.ts`.
2. `monolithic_install_request_data_arch.md`: Analyzes how `InstallRequest` couples `main` installation properties with `release-tag` installation properties.
3. `primitive_obsession_repository_slug_data_arch.md`: Identifies the use of primitive strings for repository IDs rather than using the domain `RepositorySlug` interface.

The events follow the specified schema, include clear context, and pinpoint the exact files and lines of evidence for each anti-pattern. Tests have also been run and pass cleanly.

---
*PR created automatically by Jules for task [16561383350876300774](https://jules.google.com/task/16561383350876300774) started by @akitorahayashi*