### PR TITLE
Emit coverage observer events

### DIFF
--- a/.jules/exchange/events/action_entry_point_uncovered_cov.md
+++ b/.jules/exchange/events/action_entry_point_uncovered_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-05-18"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The main entry point for the GitHub Action (`src/index.ts`) has 0% test coverage.
+
+## Goal
+
+Ensure the `run()` function in the main entry point is covered by tests, verifying that it correctly interprets inputs, routes the request to either a release install or a main source build, and gracefully handles errors.
+
+## Context
+
+The `src/index.ts` file acts as the primary orchestrator for the setup action. It reads inputs, logs version resolution, emits outputs, and delegates to the appropriate installation functions based on the requested version. Because it is completely untested, it poses a high risk; any regression here could break the entire action flow for end users without CI warnings.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "1-48"
+  note: "The entirety of the file is uncovered, leaving the primary routing and error handling untested."
+
+## Change Scope
+
+- `src/index.ts`
+- `tests/index.test.ts` (new)

--- a/.jules/exchange/events/install_main_dependency_checks_uncovered_cov.md
+++ b/.jules/exchange/events/install_main_dependency_checks_uncovered_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2024-05-18"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The initial dependency checks for `cargo` and `git` in the `installMainSource` function are completely untested.
+
+## Goal
+
+Add tests to verify that appropriate errors are thrown when either `cargo` or `git` is missing from the system PATH before attempting to install from the main source.
+
+## Context
+
+The `installMainSource` function expects both `cargo` and `git` to be available. If they are absent, the code correctly throws descriptive errors to help users provision their runners. However, these specific error branches are not exercised by tests. As these are the first actions in the function, it is important to ensure their continued correctness to prevent confusing runtime failures for end users. The coverage report flags lines 28-31 and 33-34 in `src/app/install-main-source.ts`.
+
+## Evidence
+
+- path: "src/app/install-main-source.ts"
+  loc: "28-31"
+  note: "The check for `cargo` and its associated thrown error are uncovered."
+- path: "src/app/install-main-source.ts"
+  loc: "33-34"
+  note: "The check for `git` and its associated thrown error are uncovered."
+
+## Change Scope
+
+- `src/app/install-main-source.ts`
+- `tests/app/install-main-source.test.ts`

--- a/.jules/exchange/events/install_release_happy_path_uncovered_cov.md
+++ b/.jules/exchange/events/install_release_happy_path_uncovered_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-05-18"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The happy path for a newly downloaded and installed release version is uncovered by tests.
+
+## Goal
+
+Ensure the completion of the `installReleaseVersion` workflow is fully covered by tests, verifying that a newly downloaded binary is correctly made executable, moved into place, and installed on the path.
+
+## Context
+
+While testing covers the scenario where a cached binary is reused (and failure cases), it misses the critical lines that finalize a successful new download. This represents a significant gap since the primary purpose of the action is to provision the binary. Without coverage, changes to the finalization steps (e.g., pruning, moving, setting permissions) could introduce undetected regressions. Coverage metrics show lines 76-79 in `src/app/install-release.ts` are uncovered.
+
+## Evidence
+
+- path: "src/app/install-release.ts"
+  loc: "76-79"
+  note: "The final steps of the `installReleaseVersion` function (`pruneSiblingInstallDirectories`, `installBinaryOnPath`, and logging) are completely uncovered."
+
+## Change Scope
+
+- `src/app/install-release.ts`
+- `tests/app/install-release.test.ts`


### PR DESCRIPTION
Analyzed test coverage gaps and generated event files for:
- Missing coverage in the action entry point (src/index.ts).
- Missing coverage for `cargo` and `git` dependency checks in main source install.
- Missing coverage for the happy path finalization steps of release installation.

---
*PR created automatically by Jules for task [1974852679841562086](https://jules.google.com/task/1974852679841562086) started by @akitorahayashi*