### PR TITLE
chore: emit events for typescripter role

### DIFF
--- a/.jules/exchange/events/error_coercion_typescripter.md
+++ b/.jules/exchange/events/error_coercion_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-01"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Catch blocks blindly coerce `unknown` errors into `Error` instances or strings, hiding stack traces and the true source of errors.
+
+## Goal
+
+Ensure `catch` boundaries rigorously preserve and validate underlying error types without stripping `unknown` types into strings or generic errors, potentially logging or preserving the exact context of the error.
+
+## Context
+
+Catching exceptions typed as `unknown` and applying an `instanceof Error` check, then falling back to `String(error)`, is an anti-pattern. While it makes the compiler happy by narrowing `unknown`, it routinely loses valuable error metadata (such as non-error objects thrown) and hides underlying bugs when a custom error class fails to format as expected. A more robust state modeling for failures avoids this entirely, but even within a `catch` boundary, error context must be reliably converted without fallback swallowing.
+
+## Evidence
+
+- path: "src/index.ts"
+  loc: "41-47"
+  note: "The top-level `run().catch((error: unknown) => ...)` coerces the error directly via `instanceof Error` or falls back to a cast `String(error)`, losing details about the failure."
+- path: "src/app/install-main-source.ts"
+  loc: "67-69"
+  note: "The `try...catch` block around `updateGitHubSubmodules` interpolates an unknown `error` with a generic fallback `error instanceof Error ? error.message : String(error)`, masking deeper errors with a generic string cast."
+
+## Change Scope
+
+- `src/index.ts`
+- `src/app/install-main-source.ts`

--- a/.jules/exchange/events/failure_semantics_typescripter.md
+++ b/.jules/exchange/events/failure_semantics_typescripter.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-01"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Errors and failures use an implicit `throw` strategy instead of returning a modeled `Result` or explicit union type, degrading the reliability of async boundaries.
+
+## Goal
+
+Model failure semantics using explicit discriminated union types or a `Result` wrapper at system boundaries, instead of relying purely on unstructured thrown errors, so failures become visible in the type signature.
+
+## Context
+
+Throwing errors makes the failure mode of the API implicit and invisible to TypeScript's type checker. This forces callers to either assume success or wrap everything in generic `try...catch` blocks that swallow structured domain failures. In robust TypeScript layers, especially async ones like HTTP or subprocess execution, the failure is a known possible outcome, not an exception. Modeling this state explicitly using discriminated unions (e.g., `{ success: true, data: T } | { success: false, error: DomainError }`) aligns with making invalid states unrepresentable and enforces exhaustive handling of failures at compile time.
+
+## Evidence
+
+- path: "src/adapters/github/release-asset-api.ts"
+  loc: "44-55"
+  note: "`fetchReleaseAsset` relies exclusively on `throw new Error(...)` for expected HTTP failures like 401, 403, and 404, hiding the failure type from the caller."
+- path: "src/adapters/process/github-source-git.ts"
+  loc: "107-111"
+  note: "`runGitHubCommand` relies on `throw new Error(...)` to signal a failed subprocess execution instead of returning a typed success/failure struct."
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "40-49"
+  note: "`resolveGitHubHttpUsername` masks expected HTTP failures behind generic thrown errors, preventing callers from reasoning about the failure in type-safe code."
+
+## Change Scope
+
+- `src/adapters/github/release-asset-api.ts`
+- `src/adapters/process/github-source-git.ts`
+- `src/adapters/github/github-git-http-username.ts`

--- a/.jules/exchange/events/github_api_json_validation_typescripter.md
+++ b/.jules/exchange/events/github_api_json_validation_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-01"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Manual, weak JSON validation at external boundaries leads to type illusion and brittle runtime assertions.
+
+## Goal
+
+Introduce structural validation (e.g., using Zod, TypeBox, or Valibot) at API boundaries to parse `unknown` JSON payloads securely, making invalid states unrepresentable instead of relying on manual object inspection and casts.
+
+## Context
+
+TypeScript types erase at runtime. When receiving unstructured data from `fetch(...).json()`, treating the result as `unknown` and then attempting to validate it with custom `typeof data === 'object'` checks and `as Record<string, unknown>` type casts provides a false sense of security. Manual validation logic is error-prone, hard to maintain, and scales poorly as external schemas change. A dedicated parsing library ensures the data structurally matches the expected type before it enters the application core, adhering to the principle "parse, don't validate."
+
+## Evidence
+
+- path: "src/adapters/github/release-asset-api.ts"
+  loc: "4-27"
+  note: "`isReleaseMetadata` uses manual object inspection and `as Record<string, unknown>` to validate complex JSON payloads, which is brittle and verbose."
+- path: "src/adapters/github/github-git-http-username.ts"
+  loc: "4-23"
+  note: "`isGitHubUser` relies on manual type narrowing and `as Record<string, unknown>` for JSON payloads from the GitHub API."
+
+## Change Scope
+
+- `src/adapters/github/release-asset-api.ts`
+- `src/adapters/github/github-git-http-username.ts`


### PR DESCRIPTION
Added three event files for the `typescripter` observer role:
- `github_api_json_validation_typescripter.md`
- `failure_semantics_typescripter.md`
- `error_coercion_typescripter.md`

All files are placed in `.jules/exchange/events/` and contain concrete evidence from the repository.

---
*PR created automatically by Jules for task [16265905347824134013](https://jules.google.com/task/16265905347824134013) started by @akitorahayashi*