### PR TITLE
triage requirements and correct stale prose

### DIFF
--- a/.jules/exchange/requirements/deduplicate_version_parsing.md
+++ b/.jules/exchange/requirements/deduplicate_version_parsing.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/isolate_platform_tests.md
+++ b/.jules/exchange/requirements/isolate_platform_tests.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/robust_github_api_validation.md
+++ b/.jules/exchange/requirements/robust_github_api_validation.md
@@ -15,11 +15,11 @@ The GitHub API responses use type predicates with excessive `unknown` casting an
 
 - source_event: "github_api_type_validation_typescripter.md"
   path: "src/adapters/github/github-git-http-username.ts"
-  loc: "4-22"
+  loc: "4-23"
   note: "Manual type predicate `isGitHubUser` casts to `Record<string, unknown>` and checks properties loosely."
 - source_event: "github_api_type_validation_typescripter.md"
   path: "src/adapters/github/release-asset-api.ts"
-  loc: "3-24"
+  loc: "3-28"
   note: "Manual type predicate `isReleaseMetadata` casts to `Record<string, unknown>` and iterates arrays with loose runtime checks."
 - source_event: "uncovered_github_api_metadata_cov.md"
   path: "src/adapters/github/github-git-http-username.ts"

--- a/.jules/exchange/requirements/structured_error_handling.md
+++ b/.jules/exchange/requirements/structured_error_handling.md
@@ -26,7 +26,7 @@ Catching exceptions typed as `unknown` and applying an `instanceof Error` check,
 
 - source_event: "failure_semantics_typescripter.md"
   path: "src/adapters/process/github-source-git.ts"
-  loc: "107-111"
+  loc: "124-127"
   note: "`runGitHubCommand` relies on `throw new Error(...)` to signal a failed subprocess execution instead of returning a typed success/failure struct."
 
 - source_event: "failure_semantics_typescripter.md"

--- a/.jules/exchange/requirements/update_version_token_documentation.md
+++ b/.jules/exchange/requirements/update_version_token_documentation.md
@@ -1,6 +1,6 @@
 ---
 label: "docs"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal


### PR DESCRIPTION
Triaged requirement artifacts by verifying factual claims against the codebase, marking trivially scoped ones as implementation-ready, and passing through larger architectural ones. Updated stale line numbers in evidence blocks.

---
*PR created automatically by Jules for task [13699126077946231490](https://jules.google.com/task/13699126077946231490) started by @akitorahayashi*