### PR TITLE
Refactor: deduplicate version parsing

### DIFF
--- a/src/adapters/cache/binary-install-cache.ts
+++ b/src/adapters/cache/binary-install-cache.ts
@@ -10,7 +10,7 @@ import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
 import * as core from '@actions/core'
 import type { PlatformTuple } from '../../domain/platform'
-import { extractSemver } from '../../domain/version-ref'
+import { extractFirstSemverTriplet } from '../../domain/version-ref'
 
 export function resolvePlatformCacheDirectory(
   cacheRoot: string,
@@ -84,14 +84,4 @@ export function copyExecutableBinary(
 
 export function ensureExecutablePermissions(path: string): void {
   chmodSync(path, 0o755)
-}
-
-function extractFirstSemverTriplet(value: string): string | undefined {
-  for (const segment of value.split(/\s+/)) {
-    const semverCore = extractSemver(segment)
-    if (semverCore !== undefined) {
-      return semverCore
-    }
-  }
-  return undefined
 }

--- a/src/domain/version-ref.ts
+++ b/src/domain/version-ref.ts
@@ -29,3 +29,13 @@ export function parseVersionRef(versionRef: string): ParsedVersionRef {
     `Invalid version input '${normalized}'. Expected semver or 'main'.`,
   )
 }
+
+export function extractFirstSemverTriplet(value: string): string | undefined {
+  for (const token of value.split(/\s+/)) {
+    const semverCore = extractSemver(token)
+    if (semverCore !== undefined) {
+      return semverCore
+    }
+  }
+  return undefined
+}

--- a/tests/domain/version-ref.test.ts
+++ b/tests/domain/version-ref.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { extractSemver, parseVersionRef } from '../../src/domain/version-ref'
+import {
+  extractFirstSemverTriplet,
+  extractSemver,
+  parseVersionRef,
+} from '../../src/domain/version-ref'
 
 describe('setup-jlo extractSemver behavior', () => {
   it('extracts bare semver', () => {
@@ -50,5 +54,34 @@ describe('setup-jlo version ref behavior', () => {
     expect(() => parseVersionRef('latest')).toThrow(
       "Invalid version input 'latest'. Expected semver or 'main'.",
     )
+  })
+})
+
+describe('setup-jlo extractFirstSemverTriplet behavior', () => {
+  it('extracts semver from a single valid token', () => {
+    expect(extractFirstSemverTriplet('1.2.3')).toBe('1.2.3')
+  })
+
+  it('extracts semver from a valid v-prefixed token', () => {
+    expect(extractFirstSemverTriplet('v1.2.3')).toBe('1.2.3')
+  })
+
+  it('extracts the first valid semver from multiple tokens', () => {
+    expect(extractFirstSemverTriplet('jlo version 1.2.3')).toBe('1.2.3')
+    expect(extractFirstSemverTriplet('jlo v1.2.3 (abcdef)')).toBe('1.2.3')
+  })
+
+  it('ignores invalid tokens and finds the first valid semver', () => {
+    expect(extractFirstSemverTriplet('version unknown but maybe 1.2.3')).toBe('1.2.3')
+  })
+
+  it('returns undefined if no valid semver is found', () => {
+    expect(extractFirstSemverTriplet('version unknown')).toBeUndefined()
+    expect(extractFirstSemverTriplet('jlo 1.2')).toBeUndefined()
+    expect(extractFirstSemverTriplet('')).toBeUndefined()
+  })
+
+  it('handles irregular whitespace', () => {
+    expect(extractFirstSemverTriplet('  jlo   \t  v1.2.3 \n ')).toBe('1.2.3')
   })
 })

--- a/tests/domain/version-ref.test.ts
+++ b/tests/domain/version-ref.test.ts
@@ -72,7 +72,9 @@ describe('setup-jlo extractFirstSemverTriplet behavior', () => {
   })
 
   it('ignores invalid tokens and finds the first valid semver', () => {
-    expect(extractFirstSemverTriplet('version unknown but maybe 1.2.3')).toBe('1.2.3')
+    expect(extractFirstSemverTriplet('version unknown but maybe 1.2.3')).toBe(
+      '1.2.3',
+    )
   })
 
   it('returns undefined if no valid semver is found', () => {


### PR DESCRIPTION
Move `extractFirstSemverTriplet` to `version-token.ts` to deduplicate version parsing logic and ensure the adapter uses the domain as the single source of truth.

---
*PR created automatically by Jules for task [10687043855318475820](https://jules.google.com/task/10687043855318475820) started by @akitorahayashi*