### PR TITLE
refactor: Enforce structured schema validation using Zod at GitHub API boundaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@actions/core": "^1.11.1"
+        "@actions/core": "^1.11.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.5",
@@ -2751,6 +2752,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "package": "ncc build src/index.ts -o dist --license licenses.txt"
   },
   "dependencies": {
-    "@actions/core": "^1.11.1"
+    "@actions/core": "^1.11.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.5",

--- a/src/adapters/github/github-git-http-username.ts
+++ b/src/adapters/github/github-git-http-username.ts
@@ -1,25 +1,12 @@
+import { z } from 'zod'
+
 const GITHUB_API_USER_URL = 'https://api.github.com/user'
 const GITHUB_APP_INSTALLATION_TOKEN_PREFIX = 'ghs_'
 
-function isGitHubUser(
-  data: unknown,
-): data is { login?: string; type?: string } {
-  if (typeof data !== 'object' || data === null) {
-    return false
-  }
-
-  const obj = data as Record<string, unknown>
-
-  if (obj.login !== undefined && typeof obj.login !== 'string') {
-    return false
-  }
-
-  if (obj.type !== undefined && typeof obj.type !== 'string') {
-    return false
-  }
-
-  return true
-}
+const GitHubUserSchema = z.object({
+  login: z.string().optional(),
+  type: z.string().optional(),
+}).passthrough()
 
 export async function resolveGitHubHttpUsername(
   token: string,
@@ -50,12 +37,13 @@ export async function resolveGitHubHttpUsername(
   }
 
   const rawUser: unknown = await response.json()
-  if (!isGitHubUser(rawUser)) {
+  const userParseResult = GitHubUserSchema.safeParse(rawUser)
+  if (!userParseResult.success) {
     throw new Error(
       'Invalid user metadata structure received from GitHub API. Expected an object with optional string properties "login" and "type".',
     )
   }
-  const user = rawUser
+  const user = userParseResult.data
   // Bot-owned tokens also require x-access-token rather than the reported login.
   if (user.type === 'Bot') {
     return 'x-access-token'

--- a/src/adapters/github/github-git-http-username.ts
+++ b/src/adapters/github/github-git-http-username.ts
@@ -8,7 +8,7 @@ const GitHubUserSchema = z
     login: z.string().optional(),
     type: z.string().optional(),
   })
-  .passthrough()
+  .loose()
 
 export async function resolveGitHubHttpUsername(
   token: string,

--- a/src/adapters/github/github-git-http-username.ts
+++ b/src/adapters/github/github-git-http-username.ts
@@ -3,10 +3,12 @@ import { z } from 'zod'
 const GITHUB_API_USER_URL = 'https://api.github.com/user'
 const GITHUB_APP_INSTALLATION_TOKEN_PREFIX = 'ghs_'
 
-const GitHubUserSchema = z.object({
-  login: z.string().optional(),
-  type: z.string().optional(),
-}).passthrough()
+const GitHubUserSchema = z
+  .object({
+    login: z.string().optional(),
+    type: z.string().optional(),
+  })
+  .passthrough()
 
 export async function resolveGitHubHttpUsername(
   token: string,

--- a/src/adapters/github/release-asset-api.ts
+++ b/src/adapters/github/release-asset-api.ts
@@ -1,14 +1,20 @@
 import { parseRepositorySlug } from '../../domain/repository-slug'
 import { z } from 'zod'
 
-const ReleaseMetadataSchema = z.object({
-  assets: z.array(
-    z.object({
-      id: z.number(),
-      name: z.string(),
-    }).passthrough()
-  ).optional(),
-}).passthrough()
+const ReleaseMetadataSchema = z
+  .object({
+    assets: z
+      .array(
+        z
+          .object({
+            id: z.number(),
+            name: z.string(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+  })
+  .passthrough()
 
 export async function fetchReleaseAsset(options: {
   token: string

--- a/src/adapters/github/release-asset-api.ts
+++ b/src/adapters/github/release-asset-api.ts
@@ -10,11 +10,11 @@ const ReleaseMetadataSchema = z
             id: z.number(),
             name: z.string(),
           })
-          .passthrough(),
+          .loose(),
       )
       .optional(),
   })
-  .passthrough()
+  .loose()
 
 export async function fetchReleaseAsset(options: {
   token: string

--- a/src/adapters/github/release-asset-api.ts
+++ b/src/adapters/github/release-asset-api.ts
@@ -1,31 +1,14 @@
 import { parseRepositorySlug } from '../../domain/repository-slug'
+import { z } from 'zod'
 
-function isReleaseMetadata(
-  data: unknown,
-): data is { assets?: Array<{ id: number; name: string }> } {
-  if (typeof data !== 'object' || data === null) {
-    return false
-  }
-
-  const obj = data as Record<string, unknown>
-
-  if (obj.assets === undefined) {
-    return true
-  }
-
-  return (
-    Array.isArray(obj.assets) &&
-    obj.assets.every((asset: unknown) => {
-      if (typeof asset !== 'object' || asset === null) {
-        return false
-      }
-      const assetObj = asset as Record<string, unknown>
-      return (
-        typeof assetObj.id === 'number' && typeof assetObj.name === 'string'
-      )
-    })
-  )
-}
+const ReleaseMetadataSchema = z.object({
+  assets: z.array(
+    z.object({
+      id: z.number(),
+      name: z.string(),
+    }).passthrough()
+  ).optional(),
+}).passthrough()
 
 export async function fetchReleaseAsset(options: {
   token: string
@@ -62,12 +45,13 @@ export async function fetchReleaseAsset(options: {
   }
 
   const rawMetadata: unknown = await metadataResponse.json()
-  if (!isReleaseMetadata(rawMetadata)) {
+  const metadataParseResult = ReleaseMetadataSchema.safeParse(rawMetadata)
+  if (!metadataParseResult.success) {
     throw new Error(
       `Invalid release metadata structure received from GitHub API for '${options.tagVersion}' in '${options.releaseRepository}'. Expected an object with an optional 'assets' array containing 'id' (number) and 'name' (string).`,
     )
   }
-  const metadata = rawMetadata
+  const metadata = metadataParseResult.data
   const matchedAsset = options.candidates
     .map((candidate) =>
       metadata.assets?.find((asset) => asset.name === candidate),


### PR DESCRIPTION
This PR introduces `zod` to replace custom type guard functions for validating complex external JSON payloads from the GitHub API.

Key changes:
- `src/adapters/github/release-asset-api.ts`: Replaced `isReleaseMetadata` with `ReleaseMetadataSchema` (`zod` schema) to validate release metadata JSON.
- `src/adapters/github/github-git-http-username.ts`: Replaced `isGitHubUser` with `GitHubUserSchema` (`zod` schema) to validate user JSON payloads.
- Added `.passthrough()` for schemas to ensure flexibility against undocumented fields.
- Preserved existing exact string error messages thrown to ensure full backward compatibility with the test suite.
- Replaced explicit manual type casts (e.g. `as Record<string, unknown>`) with the result of `.safeParse`.

---
*PR created automatically by Jules for task [6186322528033843939](https://jules.google.com/task/6186322528033843939) started by @akitorahayashi*