### PR TITLE
Refactor spawnSync test assertions to use partial matching

### DIFF
--- a/tests/adapters/process/cargo-build.test.ts
+++ b/tests/adapters/process/cargo-build.test.ts
@@ -62,7 +62,12 @@ describe('cargo-build adapter', () => {
 
       expect(childProcess.spawnSync).toHaveBeenCalledWith(
         'cargo',
-        ['build', '--release', '--manifest-path', '/src/Cargo.toml'],
+        expect.arrayContaining([
+          'build',
+          '--release',
+          '--manifest-path',
+          '/src/Cargo.toml',
+        ]),
         expect.objectContaining({
           cwd: '/src',
           env: expect.objectContaining({


### PR DESCRIPTION
This pull request implements the test refactoring to reduce tight coupling to the exact structural array arguments of `child_process.spawnSync`. 

Changes:
- **`tests/adapters/process/cargo-build.test.ts`**: Replaced the exact array assertion `['build', '--release', '--manifest-path', '/src/Cargo.toml']` with `expect.arrayContaining(['build', '--release', '--manifest-path', '/src/Cargo.toml'])`.
- **`tests/adapters/process/github-source-git.test.ts`**: Upon reviewing the file, it was discovered that `cloneGitHubBranch` and `updateGitHubSubmodules` already use `expect.arrayContaining` and explicitly check for critical flags like `--depth=1`. Thus, no changes were necessary in this file to fulfill the requirements, and maintaining the current checks avoids the risk of making assertions too loose.

All tests have been verified to pass.

---
*PR created automatically by Jules for task [11092228475100375679](https://jules.google.com/task/11092228475100375679) started by @akitorahayashi*