### PR TITLE
Improve orchestration test coverage and remove obsolete mock boundaries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export function resolveInstallMode(versionRef: string): 'release-tag' | 'main' {
   return parseVersionRef(versionRef).kind
 }
 
-async function run(): Promise<void> {
+export async function run(): Promise<void> {
   const token = readRequiredInput('token')
   const versionRef = readRequiredInput('version')
   const submoduleToken = readOptionalInput('submodule_token')

--- a/tests/app/install-main-source.test.ts
+++ b/tests/app/install-main-source.test.ts
@@ -118,7 +118,7 @@ describe('app install main-source orchestration', () => {
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo main')
 
-    expect(readdirSync(mockTempDirectory).length).toBe(0) // Temporary clone dir cleaned up
+    expect(readdirSync(mockTempDirectory)).toEqual([])
   })
 
   it('fetches required submodules and builds when not cached', async () => {
@@ -144,7 +144,7 @@ describe('app install main-source orchestration', () => {
 
     const installDir = join(mockCacheRoot, 'linux-x86_64', 'main-0123456789ab')
     expect(readdirSync(installDir)).toContain('jlo')
-    expect(readdirSync(mockTempDirectory).length).toBe(1) // Only mockBuiltBinary remains
+    expect(readdirSync(mockTempDirectory)).toEqual(['mock-built-binary'])
   })
 
   it('fails when main install omits submodule token', async () => {
@@ -175,7 +175,7 @@ describe('app install main-source orchestration', () => {
       'Failed to fetch required git submodules for source build (verify submodule_token can read submodule repositories): Git fetch failed',
     )
 
-    expect(readdirSync(mockTempDirectory).length).toBe(0)
+    expect(readdirSync(mockTempDirectory)).toEqual([])
   })
 
   it('fails when cargo is not installed on PATH', async () => {
@@ -225,6 +225,6 @@ describe('app install main-source orchestration', () => {
       /Failed to fetch required git submodules.*: fatal: repository not found/,
     )
 
-    expect(readdirSync(mockTempDirectory).length).toBe(0)
+    expect(readdirSync(mockTempDirectory)).toEqual([])
   })
 })

--- a/tests/app/install-main-source.test.ts
+++ b/tests/app/install-main-source.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { mkdtempSync, rmSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs'
+import {
+  mkdtempSync,
+  rmSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 

--- a/tests/app/install-main-source.test.ts
+++ b/tests/app/install-main-source.test.ts
@@ -1,61 +1,35 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mkdtempSync, rmSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
 const {
   info,
-  existsSync,
-  mkdtempSync,
-  rmSync,
   resolveGitHubHttpUsername,
   commandExists,
   cloneGitHubBranch,
   resolveGitWorktreeHeadSha,
   updateGitHubSubmodules,
   detectPlatformTuple,
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  installBinaryOnPath,
-  pruneSiblingInstallDirectories,
   detectBinaryVersion,
   buildCargoRelease,
-  copyExecutableBinary,
-  tmpdir,
+  installBinaryOnPath,
 } = vi.hoisted(() => ({
   info: vi.fn(),
-  existsSync: vi.fn(),
-  mkdtempSync: vi.fn(),
-  rmSync: vi.fn(),
   resolveGitHubHttpUsername: vi.fn(),
   commandExists: vi.fn(),
   cloneGitHubBranch: vi.fn(),
   resolveGitWorktreeHeadSha: vi.fn(),
   updateGitHubSubmodules: vi.fn(),
   detectPlatformTuple: vi.fn(),
-  resolvePlatformCacheDirectory: vi.fn(),
-  ensureInstallDirectory: vi.fn(),
-  installBinaryOnPath: vi.fn(),
-  pruneSiblingInstallDirectories: vi.fn(),
   detectBinaryVersion: vi.fn(),
   buildCargoRelease: vi.fn(),
-  copyExecutableBinary: vi.fn(),
-  tmpdir: vi.fn(),
+  installBinaryOnPath: vi.fn(),
 }))
 
 vi.mock('@actions/core', () => ({
   info,
-}))
-
-vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return {
-    ...actual,
-    existsSync,
-    mkdtempSync,
-    rmSync,
-  }
-})
-
-vi.mock('node:os', () => ({
-  tmpdir,
 }))
 
 vi.mock('../../src/adapters/github/github-git-http-username', () => ({
@@ -73,14 +47,16 @@ vi.mock('../../src/domain/platform', () => ({
   detectPlatformTuple,
 }))
 
-vi.mock('../../src/adapters/cache/binary-install-cache', () => ({
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  installBinaryOnPath,
-  pruneSiblingInstallDirectories,
-  detectBinaryVersion,
-  copyExecutableBinary,
-}))
+vi.mock('../../src/adapters/cache/binary-install-cache', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../src/adapters/cache/binary-install-cache')
+  >('../../src/adapters/cache/binary-install-cache')
+  return {
+    ...actual,
+    detectBinaryVersion,
+    installBinaryOnPath,
+  }
+})
 
 vi.mock('../../src/adapters/process/cargo-build', () => ({
   buildCargoRelease,
@@ -89,62 +65,80 @@ vi.mock('../../src/adapters/process/cargo-build', () => ({
 import { installMainSource } from '../../src/app/install-main-source'
 
 describe('app install main-source orchestration', () => {
-  const MOCK_TMP_DIR = '/tmp'
-  const MOCK_CLONE_PATH = '/tmp/setup-jlo-main-1234'
-  const MOCK_BUILD_PATH = '/tmp/jlo'
+  let tempTestDir: string
+  let mockCacheRoot: string
+  let mockTempDirectory: string
 
   beforeEach(() => {
     vi.clearAllMocks()
+    tempTestDir = mkdtempSync(join(tmpdir(), 'vitest-setup-jlo-main-source-'))
+    mockCacheRoot = join(tempTestDir, 'cache')
+    mockTempDirectory = join(tempTestDir, 'runner-temp')
+    mkdirSync(mockCacheRoot, { recursive: true })
+    mkdirSync(mockTempDirectory, { recursive: true })
+
     resolveGitHubHttpUsername.mockResolvedValue('jlo-user')
     commandExists.mockReturnValue(true)
     resolveGitWorktreeHeadSha.mockReturnValue(
       '0123456789abcdef0123456789abcdef01234567',
     )
     detectPlatformTuple.mockReturnValue({ os: 'linux', arch: 'x86_64' })
-    resolvePlatformCacheDirectory.mockReturnValue('/cache/linux-x86_64')
-    ensureInstallDirectory.mockReturnValue(
-      '/cache/linux-x86_64/main-0123456789ab',
-    )
-    existsSync.mockReturnValue(true)
     detectBinaryVersion.mockReturnValue('jlo main')
-    tmpdir.mockReturnValue(MOCK_TMP_DIR)
-    mkdtempSync.mockReturnValue(MOCK_CLONE_PATH)
+  })
+
+  afterEach(() => {
+    if (tempTestDir) {
+      rmSync(tempTestDir, { recursive: true, force: true })
+    }
   })
 
   it('reuses cached main binary and skips build', async () => {
+    const installDir = join(mockCacheRoot, 'linux-x86_64', 'main-0123456789ab')
+    mkdirSync(installDir, { recursive: true })
+    writeFileSync(join(installDir, 'jlo'), 'mock-cached-binary')
+
     await installMainSource({
       token: 'token',
       submoduleToken: 'submodule-token',
       allowDarwinX8664Fallback: false,
-      cacheRoot: '/cache',
-      tempDirectory: '/tmp',
+      cacheRoot: mockCacheRoot,
+      tempDirectory: mockTempDirectory,
     })
 
     expect(updateGitHubSubmodules).not.toHaveBeenCalled()
     expect(buildCargoRelease).not.toHaveBeenCalled()
-    expect(copyExecutableBinary).not.toHaveBeenCalled()
     expect(info).toHaveBeenCalledWith(
       'jlo main@0123456789ab already cached; skipping build.',
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo main')
+
+    expect(readdirSync(mockTempDirectory).length).toBe(0) // Temporary clone dir cleaned up
   })
 
-  it('fetches required submodules with submodule token', async () => {
-    existsSync.mockReturnValue(false)
-    buildCargoRelease.mockReturnValue(MOCK_BUILD_PATH)
+  it('fetches required submodules and builds when not cached', async () => {
+    buildCargoRelease.mockImplementation(() => {
+      const mockBuiltBinary = join(mockTempDirectory, 'mock-built-binary')
+      writeFileSync(mockBuiltBinary, 'built-data')
+      return mockBuiltBinary
+    })
 
     await installMainSource({
       token: 'token',
       submoduleToken: 'submodule-token',
       allowDarwinX8664Fallback: false,
-      cacheRoot: '/cache',
-      tempDirectory: '/tmp',
+      cacheRoot: mockCacheRoot,
+      tempDirectory: mockTempDirectory,
     })
 
     expect(info).toHaveBeenCalledWith(
       'Using submodule_token for required submodule fetch.',
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo main')
+    expect(buildCargoRelease).toHaveBeenCalled()
+
+    const installDir = join(mockCacheRoot, 'linux-x86_64', 'main-0123456789ab')
+    expect(readdirSync(installDir)).toContain('jlo')
+    expect(readdirSync(mockTempDirectory).length).toBe(1) // Only mockBuiltBinary remains
   })
 
   it('fails when main install omits submodule token', async () => {
@@ -152,14 +146,13 @@ describe('app install main-source orchestration', () => {
       installMainSource({
         token: 'token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot: mockCacheRoot,
+        tempDirectory: mockTempDirectory,
       }),
     ).rejects.toThrow('main install requires submodule_token.')
   })
 
   it('fails and cleans up temp directory if submodule update fails', async () => {
-    existsSync.mockReturnValue(false)
     updateGitHubSubmodules.mockImplementation(() => {
       throw new Error('Git fetch failed')
     })
@@ -169,17 +162,14 @@ describe('app install main-source orchestration', () => {
         token: 'token',
         submoduleToken: 'submodule-token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot: mockCacheRoot,
+        tempDirectory: mockTempDirectory,
       }),
     ).rejects.toThrow(
       'Failed to fetch required git submodules for source build (verify submodule_token can read submodule repositories): Git fetch failed',
     )
 
-    expect(rmSync).toHaveBeenCalledWith(MOCK_CLONE_PATH, {
-      recursive: true,
-      force: true,
-    })
+    expect(readdirSync(mockTempDirectory).length).toBe(0)
   })
 
   it('fails when cargo is not installed on PATH', async () => {
@@ -190,8 +180,8 @@ describe('app install main-source orchestration', () => {
         token: 'token',
         submoduleToken: 'submodule-token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot: mockCacheRoot,
+        tempDirectory: mockTempDirectory,
       }),
     ).rejects.toThrow(
       'main install requires cargo on PATH. Provision Rust toolchain on the runner.',
@@ -206,14 +196,13 @@ describe('app install main-source orchestration', () => {
         token: 'token',
         submoduleToken: 'submodule-token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot: mockCacheRoot,
+        tempDirectory: mockTempDirectory,
       }),
     ).rejects.toThrow('main install requires git on PATH.')
   })
 
   it('safely wraps non-Error strings thrown during submodule updates', async () => {
-    existsSync.mockReturnValue(false)
     updateGitHubSubmodules.mockImplementation(() => {
       throw 'fatal: repository not found'
     })
@@ -223,11 +212,13 @@ describe('app install main-source orchestration', () => {
         token: 'token',
         submoduleToken: 'submodule-token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot: mockCacheRoot,
+        tempDirectory: mockTempDirectory,
       }),
     ).rejects.toThrow(
       /Failed to fetch required git submodules.*: fatal: repository not found/,
     )
+
+    expect(readdirSync(mockTempDirectory).length).toBe(0)
   })
 })

--- a/tests/app/install-release.test.ts
+++ b/tests/app/install-release.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { mkdtempSync, rmSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs'
+import {
+  mkdtempSync,
+  rmSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -50,7 +56,6 @@ vi.mock('../../src/adapters/github/release-asset-api', () => ({
 
 import { installReleaseVersion } from '../../src/app/install-release'
 import { isCachedBinaryForVersion } from '../../src/adapters/cache/binary-install-cache'
-
 
 describe('app install release orchestration', () => {
   let tempTestDir: string

--- a/tests/app/install-release.test.ts
+++ b/tests/app/install-release.test.ts
@@ -136,7 +136,7 @@ describe('app install release orchestration', () => {
 
     const installDir = join(mockCacheRoot, 'linux-x86_64', 'v1.2.3')
     expect(readdirSync(installDir)).toContain('jlo')
-    expect(readdirSync(mockTempDirectory).length).toBe(0) // Download temp dir cleaned up
+    expect(readdirSync(mockTempDirectory)).toEqual([])
   })
 
   it('fails and cleans up temp directory if downloaded asset is empty', async () => {
@@ -163,7 +163,7 @@ describe('app install release orchestration', () => {
       "Downloaded release asset 'jlo-linux-x86_64' is missing or empty in 'asterismhq/jlo' (v1.2.3).",
     )
 
-    expect(readdirSync(mockTempDirectory).length).toBe(0)
+    expect(readdirSync(mockTempDirectory)).toEqual([])
   })
 
   it('cleans up temp directory if ensureExecutablePermissions throws', async () => {
@@ -191,6 +191,6 @@ describe('app install release orchestration', () => {
       ),
     ).rejects.toThrow('Permission denied')
 
-    expect(readdirSync(mockTempDirectory).length).toBe(0)
+    expect(readdirSync(mockTempDirectory)).toEqual([])
   })
 })

--- a/tests/app/install-release.test.ts
+++ b/tests/app/install-release.test.ts
@@ -1,57 +1,29 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mkdtempSync, rmSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
 const {
   info,
   detectPlatformTuple,
   buildReleaseAssetCandidates,
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  isCachedBinaryForVersion,
-  pruneSiblingInstallDirectories,
   installBinaryOnPath,
   detectBinaryVersion,
   fetchReleaseAsset,
   ensureExecutablePermissions,
-  mkdtempSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-  tmpdir,
 } = vi.hoisted(() => ({
   info: vi.fn(),
   detectPlatformTuple: vi.fn(),
   buildReleaseAssetCandidates: vi.fn(),
-  resolvePlatformCacheDirectory: vi.fn(),
-  ensureInstallDirectory: vi.fn(),
-  isCachedBinaryForVersion: vi.fn(),
-  pruneSiblingInstallDirectories: vi.fn(),
   installBinaryOnPath: vi.fn(),
   detectBinaryVersion: vi.fn(),
   fetchReleaseAsset: vi.fn(),
   ensureExecutablePermissions: vi.fn(),
-  mkdtempSync: vi.fn(),
-  renameSync: vi.fn(),
-  rmSync: vi.fn(),
-  statSync: vi.fn(),
-  writeFileSync: vi.fn(),
-  tmpdir: vi.fn(),
 }))
 
 vi.mock('@actions/core', () => ({
   info,
-}))
-
-vi.mock('node:fs', () => ({
-  mkdtempSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-}))
-
-vi.mock('node:os', () => ({
-  tmpdir,
 }))
 
 vi.mock('../../src/domain/platform', () => ({
@@ -59,43 +31,64 @@ vi.mock('../../src/domain/platform', () => ({
   buildReleaseAssetCandidates,
 }))
 
-vi.mock('../../src/adapters/cache/binary-install-cache', () => ({
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  isCachedBinaryForVersion,
-  pruneSiblingInstallDirectories,
-  installBinaryOnPath,
-  detectBinaryVersion,
-  ensureExecutablePermissions,
-}))
+vi.mock('../../src/adapters/cache/binary-install-cache', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../src/adapters/cache/binary-install-cache')
+  >('../../src/adapters/cache/binary-install-cache')
+  return {
+    ...actual,
+    installBinaryOnPath,
+    detectBinaryVersion,
+    ensureExecutablePermissions,
+    isCachedBinaryForVersion: vi.fn(),
+  }
+})
 
 vi.mock('../../src/adapters/github/release-asset-api', () => ({
   fetchReleaseAsset,
 }))
 
 import { installReleaseVersion } from '../../src/app/install-release'
+import { isCachedBinaryForVersion } from '../../src/adapters/cache/binary-install-cache'
+
 
 describe('app install release orchestration', () => {
-  const MOCK_TMP_DIR = '/tmp'
-  const MOCK_DOWNLOAD_PATH = '/tmp/setup-jlo-release-1234'
+  let tempTestDir: string
+  let mockCacheRoot: string
+  let mockTempDirectory: string
 
   beforeEach(() => {
     vi.clearAllMocks()
+    tempTestDir = mkdtempSync(join(tmpdir(), 'vitest-setup-jlo-release-'))
+    mockCacheRoot = join(tempTestDir, 'cache')
+    mockTempDirectory = join(tempTestDir, 'runner-temp')
+    mkdirSync(mockCacheRoot, { recursive: true })
+    mkdirSync(mockTempDirectory, { recursive: true })
+
     detectPlatformTuple.mockReturnValue({ os: 'linux', arch: 'x86_64' })
     buildReleaseAssetCandidates.mockReturnValue(['jlo-linux-x86_64'])
-    resolvePlatformCacheDirectory.mockReturnValue('/cache/linux-x86_64')
-    ensureInstallDirectory.mockReturnValue('/cache/linux-x86_64/v1.2.3')
-    isCachedBinaryForVersion.mockReturnValue(true)
     detectBinaryVersion.mockReturnValue('jlo 1.2.3')
+    vi.mocked(isCachedBinaryForVersion).mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    if (tempTestDir) {
+      rmSync(tempTestDir, { recursive: true, force: true })
+    }
   })
 
   it('reuses cached release binary and skips release download', async () => {
+    vi.mocked(isCachedBinaryForVersion).mockReturnValue(true)
+    const installDir = join(mockCacheRoot, 'linux-x86_64', 'v1.2.3')
+    mkdirSync(installDir, { recursive: true })
+    writeFileSync(join(installDir, 'jlo'), 'jlo 1.2.3')
+
     await installReleaseVersion(
       {
         token: 'token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot: mockCacheRoot,
+        tempDirectory: mockTempDirectory,
       },
       {
         kind: 'release-tag',
@@ -112,23 +105,48 @@ describe('app install release orchestration', () => {
     expect(info).toHaveBeenCalledWith('jlo installed: jlo 1.2.3')
   })
 
+  it('downloads release asset and places it in cache', async () => {
+    fetchReleaseAsset.mockResolvedValue({
+      name: 'jlo-linux-x86_64',
+      contents: Buffer.from('binary-data'),
+    })
+
+    await installReleaseVersion(
+      {
+        token: 'token',
+        allowDarwinX8664Fallback: false,
+        cacheRoot: mockCacheRoot,
+        tempDirectory: mockTempDirectory,
+      },
+      {
+        kind: 'release-tag',
+        version: '1.2.3',
+        tag: 'v1.2.3',
+      },
+    )
+
+    expect(fetchReleaseAsset).toHaveBeenCalled()
+    expect(ensureExecutablePermissions).toHaveBeenCalled()
+    expect(installBinaryOnPath).toHaveBeenCalled()
+
+    const installDir = join(mockCacheRoot, 'linux-x86_64', 'v1.2.3')
+    expect(readdirSync(installDir)).toContain('jlo')
+    expect(readdirSync(mockTempDirectory).length).toBe(0) // Download temp dir cleaned up
+  })
+
   it('fails and cleans up temp directory if downloaded asset is empty', async () => {
-    isCachedBinaryForVersion.mockReturnValue(false)
-    tmpdir.mockReturnValue(MOCK_TMP_DIR)
-    mkdtempSync.mockReturnValue(MOCK_DOWNLOAD_PATH)
     fetchReleaseAsset.mockResolvedValue({
       name: 'jlo-linux-x86_64',
       contents: Buffer.from(''),
     })
-    statSync.mockReturnValue({ size: 0 })
 
     await expect(
       installReleaseVersion(
         {
           token: 'token',
           allowDarwinX8664Fallback: false,
-          cacheRoot: '/cache',
-          tempDirectory: '/tmp',
+          cacheRoot: mockCacheRoot,
+          tempDirectory: mockTempDirectory,
         },
         {
           kind: 'release-tag',
@@ -140,21 +158,14 @@ describe('app install release orchestration', () => {
       "Downloaded release asset 'jlo-linux-x86_64' is missing or empty in 'asterismhq/jlo' (v1.2.3).",
     )
 
-    expect(rmSync).toHaveBeenCalledWith(MOCK_DOWNLOAD_PATH, {
-      recursive: true,
-      force: true,
-    })
+    expect(readdirSync(mockTempDirectory).length).toBe(0)
   })
 
   it('cleans up temp directory if ensureExecutablePermissions throws', async () => {
-    isCachedBinaryForVersion.mockReturnValue(false)
-    tmpdir.mockReturnValue(MOCK_TMP_DIR)
-    mkdtempSync.mockReturnValue(MOCK_DOWNLOAD_PATH)
     fetchReleaseAsset.mockResolvedValue({
       name: 'jlo-linux-x86_64',
       contents: Buffer.from('binary-data'),
     })
-    statSync.mockReturnValue({ size: 100 })
     ensureExecutablePermissions.mockImplementation(() => {
       throw new Error('Permission denied')
     })
@@ -164,8 +175,8 @@ describe('app install release orchestration', () => {
         {
           token: 'token',
           allowDarwinX8664Fallback: false,
-          cacheRoot: '/cache',
-          tempDirectory: '/tmp',
+          cacheRoot: mockCacheRoot,
+          tempDirectory: mockTempDirectory,
         },
         {
           kind: 'release-tag',
@@ -175,9 +186,6 @@ describe('app install release orchestration', () => {
       ),
     ).rejects.toThrow('Permission denied')
 
-    expect(rmSync).toHaveBeenCalledWith(MOCK_DOWNLOAD_PATH, {
-      recursive: true,
-      force: true,
-    })
+    expect(readdirSync(mockTempDirectory).length).toBe(0)
   })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -153,7 +153,7 @@ describe('orchestrator (src/index.ts)', () => {
       expect(installMainSource).not.toHaveBeenCalled()
     })
 
-    it('throws errors directly, leaving setFailed to the caller (if require.main block catches it)', async () => {
+    it('propagates errors to the caller', async () => {
       parseVersionRef.mockImplementation(() => {
         throw new Error('Invalid version')
       })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -77,7 +77,11 @@ describe('orchestrator (src/index.ts)', () => {
       expect(resolveInstallMode('main')).toBe('main')
       expect(parseVersionRef).toHaveBeenCalledWith('main')
 
-      parseVersionRef.mockReturnValue({ kind: 'release-tag', version: '1.0.0', tag: 'v1.0.0' })
+      parseVersionRef.mockReturnValue({
+        kind: 'release-tag',
+        version: '1.0.0',
+        tag: 'v1.0.0',
+      })
       expect(resolveInstallMode('1.0.0')).toBe('release-tag')
       expect(parseVersionRef).toHaveBeenCalledWith('1.0.0')
     })
@@ -114,7 +118,11 @@ describe('orchestrator (src/index.ts)', () => {
     })
 
     it('invokes installReleaseVersion when version kind is release-tag', async () => {
-      const mockParsedVersion = { kind: 'release-tag', version: '1.2.3', tag: 'v1.2.3' }
+      const mockParsedVersion = {
+        kind: 'release-tag',
+        version: '1.2.3',
+        tag: 'v1.2.3',
+      }
       parseVersionRef.mockReturnValue(mockParsedVersion)
       readRequiredInput.mockImplementation((name: string) => {
         if (name === 'token') return 'mock-token'
@@ -138,7 +146,10 @@ describe('orchestrator (src/index.ts)', () => {
       expect(parseVersionRef).toHaveBeenCalledWith('1.2.3')
       expect(emitInstallOutputs).toHaveBeenCalledWith('1.2.3', 'release-tag')
 
-      expect(installReleaseVersion).toHaveBeenCalledWith(mockRequest, mockParsedVersion)
+      expect(installReleaseVersion).toHaveBeenCalledWith(
+        mockRequest,
+        mockParsedVersion,
+      )
       expect(installMainSource).not.toHaveBeenCalled()
     })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  info,
+  setFailed,
+  readRequiredInput,
+  readOptionalInput,
+  resolveInstallRequest,
+  emitInstallOutputs,
+  installMainSource,
+  installReleaseVersion,
+  parseVersionRef,
+} = vi.hoisted(() => ({
+  info: vi.fn(),
+  setFailed: vi.fn(),
+  readRequiredInput: vi.fn(),
+  readOptionalInput: vi.fn(),
+  resolveInstallRequest: vi.fn(),
+  emitInstallOutputs: vi.fn(),
+  installMainSource: vi.fn(),
+  installReleaseVersion: vi.fn(),
+  parseVersionRef: vi.fn(),
+}))
+
+vi.mock('@actions/core', () => ({
+  info,
+  setFailed,
+}))
+
+vi.mock('../src/action/inputs', () => ({
+  readRequiredInput,
+  readOptionalInput,
+}))
+
+vi.mock('../src/action/install-request', () => ({
+  resolveInstallRequest,
+}))
+
+vi.mock('../src/action/outputs', () => ({
+  emitInstallOutputs,
+}))
+
+vi.mock('../src/app/install-main-source', () => ({
+  installMainSource,
+}))
+
+vi.mock('../src/app/install-release', () => ({
+  installReleaseVersion,
+}))
+
+vi.mock('../src/domain/version-ref', () => ({
+  parseVersionRef,
+}))
+
+import { resolveInstallMode, run } from '../src/index'
+
+describe('orchestrator (src/index.ts)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    readRequiredInput.mockImplementation((name: string) => {
+      if (name === 'token') return 'mock-token'
+      if (name === 'version') return 'mock-version'
+      return 'mock-input'
+    })
+    readOptionalInput.mockReturnValue(undefined)
+    resolveInstallRequest.mockReturnValue({
+      token: 'mock-token',
+      allowDarwinX8664Fallback: false,
+      cacheRoot: '/cache',
+      tempDirectory: '/tmp',
+    })
+  })
+
+  describe('resolveInstallMode', () => {
+    it('returns kind from parseVersionRef', () => {
+      parseVersionRef.mockReturnValue({ kind: 'main', ref: 'main' })
+      expect(resolveInstallMode('main')).toBe('main')
+      expect(parseVersionRef).toHaveBeenCalledWith('main')
+
+      parseVersionRef.mockReturnValue({ kind: 'release-tag', version: '1.0.0', tag: 'v1.0.0' })
+      expect(resolveInstallMode('1.0.0')).toBe('release-tag')
+      expect(parseVersionRef).toHaveBeenCalledWith('1.0.0')
+    })
+  })
+
+  describe('run', () => {
+    it('invokes installMainSource when version kind is main', async () => {
+      parseVersionRef.mockReturnValue({ kind: 'main', ref: 'main' })
+      readRequiredInput.mockImplementation((name: string) => {
+        if (name === 'token') return 'mock-token'
+        if (name === 'version') return 'main'
+        return 'mock-input'
+      })
+      const mockRequest = {
+        token: 'mock-token',
+        submoduleToken: 'mock-submodule-token',
+        allowDarwinX8664Fallback: false,
+        cacheRoot: '/cache',
+        tempDirectory: '/tmp',
+      }
+      resolveInstallRequest.mockReturnValue(mockRequest)
+
+      await run()
+
+      expect(readRequiredInput).toHaveBeenCalledWith('token')
+      expect(readRequiredInput).toHaveBeenCalledWith('version')
+      expect(readOptionalInput).toHaveBeenCalledWith('submodule_token')
+
+      expect(parseVersionRef).toHaveBeenCalledWith('main')
+      expect(emitInstallOutputs).toHaveBeenCalledWith('main', 'main')
+
+      expect(installMainSource).toHaveBeenCalledWith(mockRequest)
+      expect(installReleaseVersion).not.toHaveBeenCalled()
+    })
+
+    it('invokes installReleaseVersion when version kind is release-tag', async () => {
+      const mockParsedVersion = { kind: 'release-tag', version: '1.2.3', tag: 'v1.2.3' }
+      parseVersionRef.mockReturnValue(mockParsedVersion)
+      readRequiredInput.mockImplementation((name: string) => {
+        if (name === 'token') return 'mock-token'
+        if (name === 'version') return '1.2.3'
+        return 'mock-input'
+      })
+      const mockRequest = {
+        token: 'mock-token',
+        allowDarwinX8664Fallback: false,
+        cacheRoot: '/cache',
+        tempDirectory: '/tmp',
+      }
+      resolveInstallRequest.mockReturnValue(mockRequest)
+
+      await run()
+
+      expect(readRequiredInput).toHaveBeenCalledWith('token')
+      expect(readRequiredInput).toHaveBeenCalledWith('version')
+      expect(readOptionalInput).toHaveBeenCalledWith('submodule_token')
+
+      expect(parseVersionRef).toHaveBeenCalledWith('1.2.3')
+      expect(emitInstallOutputs).toHaveBeenCalledWith('1.2.3', 'release-tag')
+
+      expect(installReleaseVersion).toHaveBeenCalledWith(mockRequest, mockParsedVersion)
+      expect(installMainSource).not.toHaveBeenCalled()
+    })
+
+    it('throws errors directly, leaving setFailed to the caller (if require.main block catches it)', async () => {
+      parseVersionRef.mockImplementation(() => {
+        throw new Error('Invalid version')
+      })
+
+      await expect(run()).rejects.toThrow('Invalid version')
+    })
+  })
+})


### PR DESCRIPTION
Added test coverage for the primary orchestrator `src/index.ts`. Refactored main source and release orchestration test suites to verify externally observable outcomes using real deterministic temporary directories instead of heavily mocking internal file system dependencies.

---
*PR created automatically by Jules for task [2471969516801888739](https://jules.google.com/task/2471969516801888739) started by @akitorahayashi*