### PR TITLE
Refactor APIs to enforce `RepositorySlug` object invariants

### DIFF
--- a/src/adapters/github/release-asset-api.ts
+++ b/src/adapters/github/release-asset-api.ts
@@ -1,4 +1,4 @@
-import { parseRepositorySlug } from '../../domain/repository-slug'
+import type { RepositorySlug } from '../../domain/repository-slug'
 
 function isReleaseMetadata(
   data: unknown,
@@ -29,11 +29,11 @@ function isReleaseMetadata(
 
 export async function fetchReleaseAsset(options: {
   token: string
-  releaseRepository: string
+  releaseRepository: RepositorySlug
   tagVersion: string
   candidates: string[]
 }): Promise<{ name: string; contents: Buffer }> {
-  const { owner, repo } = parseRepositorySlug(options.releaseRepository)
+  const { owner, repo } = options.releaseRepository
   const headers = {
     Authorization: `Bearer ${options.token}`,
     Accept: 'application/vnd.github+json',
@@ -47,24 +47,24 @@ export async function fetchReleaseAsset(options: {
 
   if (metadataResponse.status === 401 || metadataResponse.status === 403) {
     throw new Error(
-      `token cannot access release metadata in '${options.releaseRepository}'. Ensure contents:read and organization SSO authorization.`,
+      `token cannot access release metadata in '${owner}/${repo}'. Ensure contents:read and organization SSO authorization.`,
     )
   }
   if (metadataResponse.status === 404) {
     throw new Error(
-      `Release '${options.tagVersion}' was not found (or is inaccessible) in '${options.releaseRepository}'.`,
+      `Release '${options.tagVersion}' was not found (or is inaccessible) in '${owner}/${repo}'.`,
     )
   }
   if (!metadataResponse.ok) {
     throw new Error(
-      `Failed to query release metadata for '${options.tagVersion}' in '${options.releaseRepository}' (HTTP ${metadataResponse.status}).`,
+      `Failed to query release metadata for '${options.tagVersion}' in '${owner}/${repo}' (HTTP ${metadataResponse.status}).`,
     )
   }
 
   const rawMetadata: unknown = await metadataResponse.json()
   if (!isReleaseMetadata(rawMetadata)) {
     throw new Error(
-      `Invalid release metadata structure received from GitHub API for '${options.tagVersion}' in '${options.releaseRepository}'. Expected an object with an optional 'assets' array containing 'id' (number) and 'name' (string).`,
+      `Invalid release metadata structure received from GitHub API for '${options.tagVersion}' in '${owner}/${repo}'. Expected an object with an optional 'assets' array containing 'id' (number) and 'name' (string).`,
     )
   }
   const metadata = rawMetadata
@@ -76,7 +76,7 @@ export async function fetchReleaseAsset(options: {
 
   if (!matchedAsset) {
     throw new Error(
-      `No matching release asset for ${options.candidates.join(', ')} in '${options.releaseRepository}'.`,
+      `No matching release asset for ${options.candidates.join(', ')} in '${owner}/${repo}'.`,
     )
   }
 
@@ -92,7 +92,7 @@ export async function fetchReleaseAsset(options: {
 
   if (!downloadResponse.ok) {
     throw new Error(
-      `Failed to download release asset '${matchedAsset.name}' from '${options.releaseRepository}' (HTTP ${downloadResponse.status}).`,
+      `Failed to download release asset '${matchedAsset.name}' from '${owner}/${repo}' (HTTP ${downloadResponse.status}).`,
     )
   }
 

--- a/src/adapters/process/github-source-git.ts
+++ b/src/adapters/process/github-source-git.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import type { RepositorySlug } from '../../domain/repository-slug'
 
 const GITHUB_HTTPS_BASE = 'https://github.com/'
 
@@ -10,7 +11,7 @@ export function commandExists(program: string): boolean {
 }
 
 export function cloneGitHubBranch(options: {
-  repository: string
+  repository: RepositorySlug
   branch: string
   destination: string
   token: string
@@ -31,7 +32,7 @@ export function cloneGitHubBranch(options: {
       }),
       options.destination,
     ],
-    operation: `clone ${options.repository}@${options.branch}`,
+    operation: `clone ${options.repository.owner}/${options.repository.repo}@${options.branch}`,
   })
 }
 
@@ -127,12 +128,12 @@ function runGitHubCommand(options: {
   throw new Error(`Failed to ${options.operation}: ${result.stdout.trim()}`)
 }
 
-function buildGitHubRepositoryUrl(repository: string): string {
-  return `${GITHUB_HTTPS_BASE}${repository}.git`
+function buildGitHubRepositoryUrl(repository: RepositorySlug): string {
+  return `${GITHUB_HTTPS_BASE}${repository.owner}/${repository.repo}.git`
 }
 
 function buildAuthenticatedGitHubRepositoryUrl(options: {
-  repository: string
+  repository: RepositorySlug
   username: string
   token: string
 }): string {

--- a/src/adapters/process/github-source-git.ts
+++ b/src/adapters/process/github-source-git.ts
@@ -17,6 +17,7 @@ export function cloneGitHubBranch(options: {
   token: string
   username: string
 }): void {
+  const { owner, repo } = options.repository
   runGitHubCommand({
     args: [
       'clone',
@@ -32,7 +33,7 @@ export function cloneGitHubBranch(options: {
       }),
       options.destination,
     ],
-    operation: `clone ${options.repository.owner}/${options.repository.repo}@${options.branch}`,
+    operation: `clone ${owner}/${repo}@${options.branch}`,
   })
 }
 
@@ -129,7 +130,8 @@ function runGitHubCommand(options: {
 }
 
 function buildGitHubRepositoryUrl(repository: RepositorySlug): string {
-  return `${GITHUB_HTTPS_BASE}${repository.owner}/${repository.repo}.git`
+  const { owner, repo } = repository
+  return `${GITHUB_HTTPS_BASE}${owner}/${repo}.git`
 }
 
 function buildAuthenticatedGitHubRepositoryUrl(options: {

--- a/src/app/install-main-source.ts
+++ b/src/app/install-main-source.ts
@@ -48,7 +48,9 @@ export async function installMainSource(
   try {
     // Keep source acquisition on the same authenticated clone path used by builds.
     // A separate ls-remote path previously broke main-mode auth in CI.
-    core.info(`Cloning ${JLO_REPOSITORY}@${sourceBranch} for source build.`)
+    core.info(
+      `Cloning ${JLO_REPOSITORY.owner}/${JLO_REPOSITORY.repo}@${sourceBranch} for source build.`,
+    )
 
     cloneGitHubBranch({
       repository: JLO_REPOSITORY,

--- a/src/app/install-release.ts
+++ b/src/app/install-release.ts
@@ -63,7 +63,7 @@ export async function installReleaseVersion(
     writeFileSync(downloadPath, releaseAsset.contents)
     if (statSync(downloadPath).size === 0) {
       throw new Error(
-        `Downloaded release asset '${releaseAsset.name}' is missing or empty in '${JLO_REPOSITORY}' (${versionRef.tag}).`,
+        `Downloaded release asset '${releaseAsset.name}' is missing or empty in '${JLO_REPOSITORY.owner}/${JLO_REPOSITORY.repo}' (${versionRef.tag}).`,
       )
     }
 

--- a/src/catalog/jlo.ts
+++ b/src/catalog/jlo.ts
@@ -1,1 +1,3 @@
-export const JLO_REPOSITORY = 'asterismhq/jlo'
+import { parseRepositorySlug } from '../domain/repository-slug'
+
+export const JLO_REPOSITORY = parseRepositorySlug('asterismhq/jlo')

--- a/tests/adapters/github/release-asset-api.test.ts
+++ b/tests/adapters/github/release-asset-api.test.ts
@@ -20,7 +20,7 @@ describe('release-asset-api adapter', () => {
       await expect(
         fetchReleaseAsset({
           token: 'token',
-          releaseRepository: 'owner/repo',
+          releaseRepository: { owner: 'owner', repo: 'repo' },
           tagVersion: 'v1.0.0',
           candidates: ['jlo-linux-x86_64'],
         }),
@@ -44,7 +44,7 @@ describe('release-asset-api adapter', () => {
       await expect(
         fetchReleaseAsset({
           token: 'secret',
-          releaseRepository: 'owner/repo',
+          releaseRepository: { owner: 'owner', repo: 'repo' },
           tagVersion: 'v1.0.0',
           candidates: ['asset-linux'],
         }),
@@ -65,7 +65,7 @@ describe('release-asset-api adapter', () => {
       await expect(
         fetchReleaseAsset({
           token: 'secret',
-          releaseRepository: 'owner/repo',
+          releaseRepository: { owner: 'owner', repo: 'repo' },
           tagVersion: 'v1.0.0',
           candidates: ['asset-linux'],
         }),
@@ -86,7 +86,7 @@ describe('release-asset-api adapter', () => {
       await expect(
         fetchReleaseAsset({
           token: 'secret',
-          releaseRepository: 'owner/repo',
+          releaseRepository: { owner: 'owner', repo: 'repo' },
           tagVersion: 'v1.0.0',
           candidates: ['asset-linux'],
         }),
@@ -113,7 +113,7 @@ describe('release-asset-api adapter', () => {
       await expect(
         fetchReleaseAsset({
           token: 'secret',
-          releaseRepository: 'owner/repo',
+          releaseRepository: { owner: 'owner', repo: 'repo' },
           tagVersion: 'v1.0.0',
           candidates: ['asset-linux', 'fallback-linux'],
         }),
@@ -150,7 +150,7 @@ describe('release-asset-api adapter', () => {
       await expect(
         fetchReleaseAsset({
           token: 'secret',
-          releaseRepository: 'owner/repo',
+          releaseRepository: { owner: 'owner', repo: 'repo' },
           tagVersion: 'v1.0.0',
           candidates: ['asset-linux'],
         }),
@@ -190,7 +190,7 @@ describe('release-asset-api adapter', () => {
 
       const result = await fetchReleaseAsset({
         token: 'secret',
-        releaseRepository: 'owner/repo',
+        releaseRepository: { owner: 'owner', repo: 'repo' },
         tagVersion: 'v1.0.0',
         candidates: ['asset-linux', 'fallback-linux'],
       })

--- a/tests/adapters/process/github-source-git.test.ts
+++ b/tests/adapters/process/github-source-git.test.ts
@@ -40,7 +40,7 @@ describe('github-source-git adapter', () => {
 
       expect(() =>
         cloneGitHubBranch({
-          repository: 'owner/repo',
+          repository: { owner: 'owner', repo: 'repo' },
           branch: 'main',
           destination: '/dest',
           token: 'secret',
@@ -60,7 +60,7 @@ describe('github-source-git adapter', () => {
 
       expect(() =>
         cloneGitHubBranch({
-          repository: 'owner/repo',
+          repository: { owner: 'owner', repo: 'repo' },
           branch: 'main',
           destination: '/dest',
           token: 'secret',
@@ -77,7 +77,7 @@ describe('github-source-git adapter', () => {
       } as ReturnType<typeof childProcess.spawnSync>)
 
       cloneGitHubBranch({
-        repository: 'owner/repo',
+        repository: { owner: 'owner', repo: 'repo' },
         branch: 'main',
         destination: '/dest',
         token: 'secret',


### PR DESCRIPTION
Refactors the codebase to use `RepositorySlug` as the domain type representing GitHub repositories instead of raw strings. Updates `JLO_REPOSITORY` export in the catalog, updates signature boundaries for `cloneGitHubBranch` and `fetchReleaseAsset`, and updates calling sites, tests, and formatting to conform to the object structure.

---
*PR created automatically by Jules for task [5014814833235588631](https://jules.google.com/task/5014814833235588631) started by @akitorahayashi*