### PR TITLE
refactor: implement structured error handling with Result type

### DIFF
--- a/src/adapters/cache/binary-install-cache.ts
+++ b/src/adapters/cache/binary-install-cache.ts
@@ -58,7 +58,7 @@ export function isCachedBinaryForVersion(
   }
 
   const result = spawnSync(binaryPath, ['--version'], { encoding: 'utf8' })
-  if (result.status !== 0) {
+  if (result.error || result.status !== 0) {
     return false
   }
 
@@ -67,7 +67,7 @@ export function isCachedBinaryForVersion(
 
 export function detectBinaryVersion(binaryPath: string): string {
   const result = spawnSync(binaryPath, ['--version'], { encoding: 'utf8' })
-  if (result.status !== 0) {
+  if (result.error || result.status !== 0) {
     return 'version unknown'
   }
   const rendered = result.stdout.trim()

--- a/src/adapters/github/github-git-http-username.ts
+++ b/src/adapters/github/github-git-http-username.ts
@@ -1,3 +1,5 @@
+import { err, ok, type Result } from '../../domain/result'
+
 const GITHUB_API_USER_URL = 'https://api.github.com/user'
 const GITHUB_APP_INSTALLATION_TOKEN_PREFIX = 'ghs_'
 
@@ -23,10 +25,10 @@ function isGitHubUser(
 
 export async function resolveGitHubHttpUsername(
   token: string,
-): Promise<string> {
+): Promise<Result<string>> {
   // GitHub App installation tokens authenticate git over HTTPS as x-access-token.
   if (token.startsWith(GITHUB_APP_INSTALLATION_TOKEN_PREFIX)) {
-    return 'x-access-token'
+    return ok('x-access-token')
   }
 
   const response = await fetch(GITHUB_API_USER_URL, {
@@ -38,36 +40,44 @@ export async function resolveGitHubHttpUsername(
   })
 
   if (response.status === 401 || response.status === 403) {
-    throw new Error(
-      'token cannot resolve GitHub identity for HTTPS git authentication. Ensure the token remains valid and authorized.',
+    return err(
+      new Error(
+        'token cannot resolve GitHub identity for HTTPS git authentication. Ensure the token remains valid and authorized.',
+      ),
     )
   }
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to resolve GitHub identity for HTTPS git authentication (HTTP ${response.status}).`,
+    return err(
+      new Error(
+        `Failed to resolve GitHub identity for HTTPS git authentication (HTTP ${response.status}).`,
+      ),
     )
   }
 
   const rawUser: unknown = await response.json()
   if (!isGitHubUser(rawUser)) {
-    throw new Error(
-      'Invalid user metadata structure received from GitHub API. Expected an object with optional string properties "login" and "type".',
+    return err(
+      new Error(
+        'Invalid user metadata structure received from GitHub API. Expected an object with optional string properties "login" and "type".',
+      ),
     )
   }
   const user = rawUser
   // Bot-owned tokens also require x-access-token rather than the reported login.
   if (user.type === 'Bot') {
-    return 'x-access-token'
+    return ok('x-access-token')
   }
 
   const username = user.login?.trim()
 
   if (!username) {
-    throw new Error(
-      'GitHub identity response did not include a usable login for HTTPS git authentication.',
+    return err(
+      new Error(
+        'GitHub identity response did not include a usable login for HTTPS git authentication.',
+      ),
     )
   }
 
-  return username
+  return ok(username)
 }

--- a/src/adapters/github/release-asset-api.ts
+++ b/src/adapters/github/release-asset-api.ts
@@ -1,4 +1,5 @@
 import { parseRepositorySlug } from '../../domain/repository-slug'
+import { err, ok, type Result } from '../../domain/result'
 
 function isReleaseMetadata(
   data: unknown,
@@ -32,7 +33,7 @@ export async function fetchReleaseAsset(options: {
   releaseRepository: string
   tagVersion: string
   candidates: string[]
-}): Promise<{ name: string; contents: Buffer }> {
+}): Promise<Result<{ name: string; contents: Buffer }>> {
   const { owner, repo } = parseRepositorySlug(options.releaseRepository)
   const headers = {
     Authorization: `Bearer ${options.token}`,
@@ -46,25 +47,33 @@ export async function fetchReleaseAsset(options: {
   )
 
   if (metadataResponse.status === 401 || metadataResponse.status === 403) {
-    throw new Error(
-      `token cannot access release metadata in '${options.releaseRepository}'. Ensure contents:read and organization SSO authorization.`,
+    return err(
+      new Error(
+        `token cannot access release metadata in '${options.releaseRepository}'. Ensure contents:read and organization SSO authorization.`,
+      ),
     )
   }
   if (metadataResponse.status === 404) {
-    throw new Error(
-      `Release '${options.tagVersion}' was not found (or is inaccessible) in '${options.releaseRepository}'.`,
+    return err(
+      new Error(
+        `Release '${options.tagVersion}' was not found (or is inaccessible) in '${options.releaseRepository}'.`,
+      ),
     )
   }
   if (!metadataResponse.ok) {
-    throw new Error(
-      `Failed to query release metadata for '${options.tagVersion}' in '${options.releaseRepository}' (HTTP ${metadataResponse.status}).`,
+    return err(
+      new Error(
+        `Failed to query release metadata for '${options.tagVersion}' in '${options.releaseRepository}' (HTTP ${metadataResponse.status}).`,
+      ),
     )
   }
 
   const rawMetadata: unknown = await metadataResponse.json()
   if (!isReleaseMetadata(rawMetadata)) {
-    throw new Error(
-      `Invalid release metadata structure received from GitHub API for '${options.tagVersion}' in '${options.releaseRepository}'. Expected an object with an optional 'assets' array containing 'id' (number) and 'name' (string).`,
+    return err(
+      new Error(
+        `Invalid release metadata structure received from GitHub API for '${options.tagVersion}' in '${options.releaseRepository}'. Expected an object with an optional 'assets' array containing 'id' (number) and 'name' (string).`,
+      ),
     )
   }
   const metadata = rawMetadata
@@ -75,8 +84,10 @@ export async function fetchReleaseAsset(options: {
     .find((asset): asset is { id: number; name: string } => asset !== undefined)
 
   if (!matchedAsset) {
-    throw new Error(
-      `No matching release asset for ${options.candidates.join(', ')} in '${options.releaseRepository}'.`,
+    return err(
+      new Error(
+        `No matching release asset for ${options.candidates.join(', ')} in '${options.releaseRepository}'.`,
+      ),
     )
   }
 
@@ -91,13 +102,15 @@ export async function fetchReleaseAsset(options: {
   )
 
   if (!downloadResponse.ok) {
-    throw new Error(
-      `Failed to download release asset '${matchedAsset.name}' from '${options.releaseRepository}' (HTTP ${downloadResponse.status}).`,
+    return err(
+      new Error(
+        `Failed to download release asset '${matchedAsset.name}' from '${options.releaseRepository}' (HTTP ${downloadResponse.status}).`,
+      ),
     )
   }
 
-  return {
+  return ok({
     name: matchedAsset.name,
     contents: Buffer.from(await downloadResponse.arrayBuffer()),
-  }
+  })
 }

--- a/src/adapters/process/cargo-build.ts
+++ b/src/adapters/process/cargo-build.ts
@@ -20,6 +20,12 @@ export function buildCargoRelease(options: {
     },
   )
 
+  if (buildResult.error) {
+    throw new Error(
+      `Failed to build jlo from source: ${buildResult.error.message}`,
+    )
+  }
+
   if (buildResult.status !== 0) {
     throw new Error(
       `Failed to build jlo from source: ${buildResult.stderr.trim()}`,

--- a/src/adapters/process/github-source-git.ts
+++ b/src/adapters/process/github-source-git.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { err, ok, type Result } from '../../domain/result'
 
 const GITHUB_HTTPS_BASE = 'https://github.com/'
 
@@ -15,8 +16,8 @@ export function cloneGitHubBranch(options: {
   destination: string
   token: string
   username: string
-}): void {
-  runGitHubCommand({
+}): Result<void> {
+  const result = runGitHubCommand({
     args: [
       'clone',
       '--quiet',
@@ -33,28 +34,42 @@ export function cloneGitHubBranch(options: {
     ],
     operation: `clone ${options.repository}@${options.branch}`,
   })
+
+  if (!result.ok) {
+    return err(result.error)
+  }
+
+  return ok(undefined)
 }
 
-export function resolveGitWorktreeHeadSha(options: { cwd: string }): string {
-  const output = runGitHubCommand({
+export function resolveGitWorktreeHeadSha(options: {
+  cwd: string
+}): Result<string> {
+  const result = runGitHubCommand({
     cwd: options.cwd,
     args: ['rev-parse', 'HEAD'],
     operation: 'resolve cloned source head SHA',
-  }).trim()
+  })
 
-  if (!isFullGitSha(output)) {
-    throw new Error('Failed to resolve cloned source head SHA.')
+  if (!result.ok) {
+    return err(result.error)
   }
 
-  return output
+  const output = result.value.trim()
+
+  if (!isFullGitSha(output)) {
+    return err(new Error('Failed to resolve cloned source head SHA.'))
+  }
+
+  return ok(output)
 }
 
 export function updateGitHubSubmodules(options: {
   cwd: string
   token: string
   username: string
-}): void {
-  runGitHubCommand({
+}): Result<void> {
+  const syncResult = runGitHubCommand({
     cwd: options.cwd,
     token: options.token,
     username: options.username,
@@ -62,13 +77,23 @@ export function updateGitHubSubmodules(options: {
     operation: 'sync git submodule configuration for source build',
   })
 
-  runGitHubCommand({
+  if (!syncResult.ok) {
+    return err(syncResult.error)
+  }
+
+  const updateResult = runGitHubCommand({
     cwd: options.cwd,
     token: options.token,
     username: options.username,
     args: ['submodule', 'update', '--init', '--recursive', '--depth=1'],
     operation: 'fetch git submodules for source build',
   })
+
+  if (!updateResult.ok) {
+    return err(updateResult.error)
+  }
+
+  return ok(undefined)
 }
 
 function runGitHubCommand(options: {
@@ -77,7 +102,7 @@ function runGitHubCommand(options: {
   username?: string
   args: string[]
   operation: string
-}): string {
+}): Result<string> {
   const gitArgs = [
     '-c',
     'credential.helper=',
@@ -116,15 +141,17 @@ function runGitHubCommand(options: {
   })
 
   if (result.status === 0) {
-    return result.stdout
+    return ok(result.stdout)
   }
 
   const stderr = result.stderr.trim()
   if (stderr.length > 0) {
-    throw new Error(`Failed to ${options.operation}: ${stderr}`)
+    return err(new Error(`Failed to ${options.operation}: ${stderr}`))
   }
 
-  throw new Error(`Failed to ${options.operation}: ${result.stdout.trim()}`)
+  return err(
+    new Error(`Failed to ${options.operation}: ${result.stdout.trim()}`),
+  )
 }
 
 function buildGitHubRepositoryUrl(repository: string): string {

--- a/src/adapters/process/github-source-git.ts
+++ b/src/adapters/process/github-source-git.ts
@@ -140,6 +140,12 @@ function runGitHubCommand(options: {
     },
   })
 
+  if (result.error) {
+    return err(
+      new Error(`Failed to ${options.operation}: ${result.error.message}`),
+    )
+  }
+
   if (result.status === 0) {
     return ok(result.stdout)
   }

--- a/src/app/install-main-source.ts
+++ b/src/app/install-main-source.ts
@@ -38,10 +38,21 @@ export async function installMainSource(
     throw new Error('main install requires submodule_token.')
   }
 
-  const sourceAuthUsername = await resolveGitHubHttpUsername(request.token)
-  const submoduleAuthUsername = await resolveGitHubHttpUsername(
+  const sourceAuthUsernameResult = await resolveGitHubHttpUsername(
+    request.token,
+  )
+  if (!sourceAuthUsernameResult.ok) {
+    throw sourceAuthUsernameResult.error
+  }
+  const sourceAuthUsername = sourceAuthUsernameResult.value
+
+  const submoduleAuthUsernameResult = await resolveGitHubHttpUsername(
     request.submoduleToken,
   )
+  if (!submoduleAuthUsernameResult.ok) {
+    throw submoduleAuthUsernameResult.error
+  }
+  const submoduleAuthUsername = submoduleAuthUsernameResult.value
 
   const clonePath = mkdtempSync(join(request.tempDirectory, 'setup-jlo-main-'))
 
@@ -50,15 +61,23 @@ export async function installMainSource(
     // A separate ls-remote path previously broke main-mode auth in CI.
     core.info(`Cloning ${JLO_REPOSITORY}@${sourceBranch} for source build.`)
 
-    cloneGitHubBranch({
+    const cloneResult = cloneGitHubBranch({
       repository: JLO_REPOSITORY,
       branch: sourceBranch,
       destination: clonePath,
       token: request.token,
       username: sourceAuthUsername,
     })
+    if (!cloneResult.ok) {
+      throw cloneResult.error
+    }
 
-    const sha = resolveGitWorktreeHeadSha({ cwd: clonePath })
+    const shaResult = resolveGitWorktreeHeadSha({ cwd: clonePath })
+    if (!shaResult.ok) {
+      throw shaResult.error
+    }
+    const sha = shaResult.value
+
     const platform = detectPlatformTuple()
     const shortSha = sha.slice(0, 12)
     const installKey = `main-${shortSha}`
@@ -77,15 +96,15 @@ export async function installMainSource(
 
     core.info('Using submodule_token for required submodule fetch.')
 
-    try {
-      updateGitHubSubmodules({
-        cwd: clonePath,
-        token: request.submoduleToken,
-        username: submoduleAuthUsername,
-      })
-    } catch (error) {
+    const updateResult = updateGitHubSubmodules({
+      cwd: clonePath,
+      token: request.submoduleToken,
+      username: submoduleAuthUsername,
+    })
+
+    if (!updateResult.ok) {
       throw new Error(
-        `Failed to fetch required git submodules for source build (verify submodule_token can read submodule repositories): ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to fetch required git submodules for source build (verify submodule_token can read submodule repositories): ${updateResult.error.message}`,
       )
     }
 

--- a/src/app/install-release.ts
+++ b/src/app/install-release.ts
@@ -47,12 +47,17 @@ export async function installReleaseVersion(
     platform,
     request.allowDarwinX8664Fallback,
   )
-  const releaseAsset = await fetchReleaseAsset({
+  const releaseAssetResult = await fetchReleaseAsset({
     token: request.token,
     releaseRepository: JLO_REPOSITORY,
     tagVersion: versionRef.tag,
     candidates,
   })
+
+  if (!releaseAssetResult.ok) {
+    throw releaseAssetResult.error
+  }
+  const releaseAsset = releaseAssetResult.value
 
   const tempDirectory = mkdtempSync(
     join(request.tempDirectory, 'setup-jlo-release-'),

--- a/src/domain/result.ts
+++ b/src/domain/result.ts
@@ -1,0 +1,11 @@
+export type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E }
+
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value }
+}
+
+export function err<E>(error: E): Result<never, E> {
+  return { ok: false, error }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,20 @@ async function run(): Promise<void> {
 if (require.main === module) {
   run().catch((error: unknown) => {
     if (error instanceof Error) {
+      core.setFailed(error.stack || error.message)
+      return
+    }
+
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'message' in error &&
+      typeof error.message === 'string'
+    ) {
       core.setFailed(error.message)
       return
     }
-    core.setFailed(String(error))
+
+    core.setFailed(`Unhandled rejection: ${JSON.stringify(error)}`)
   })
 }

--- a/tests/adapters/github/github-git-http-username.test.ts
+++ b/tests/adapters/github/github-git-http-username.test.ts
@@ -7,9 +7,11 @@ afterEach(() => {
 
 describe('github git http username resolution', () => {
   it('uses x-access-token for GitHub App installation tokens', async () => {
-    await expect(resolveGitHubHttpUsername('ghs_example')).resolves.toBe(
-      'x-access-token',
-    )
+    const result = await resolveGitHubHttpUsername('ghs_example')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('x-access-token')
+    }
   })
 
   it('resolves the authenticated login for personal access tokens', async () => {
@@ -22,9 +24,11 @@ describe('github git http username resolution', () => {
       }),
     )
 
-    await expect(resolveGitHubHttpUsername('github_pat_example')).resolves.toBe(
-      'jlo-user',
-    )
+    const result = await resolveGitHubHttpUsername('github_pat_example')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('jlo-user')
+    }
   })
 
   it('uses x-access-token for bot-owned tokens', async () => {
@@ -37,12 +41,14 @@ describe('github git http username resolution', () => {
       }),
     )
 
-    await expect(resolveGitHubHttpUsername('github_pat_bot')).resolves.toBe(
-      'x-access-token',
-    )
+    const result = await resolveGitHubHttpUsername('github_pat_bot')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('x-access-token')
+    }
   })
 
-  it('throws on invalid JSON response structure', async () => {
+  it('returns error on invalid JSON response structure', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -52,15 +58,17 @@ describe('github git http username resolution', () => {
       }),
     )
 
-    await expect(
-      resolveGitHubHttpUsername('github_pat_invalid'),
-    ).rejects.toThrow(/invalid/i)
+    const result = await resolveGitHubHttpUsername('github_pat_invalid')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/invalid/i)
+    }
   })
 
   it.each([
     { status: 401, description: 'unauthorized' },
     { status: 403, description: 'forbidden' },
-  ])('throws error on $status $description', async ({ status }) => {
+  ])('returns error on $status $description', async ({ status }) => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -69,14 +77,16 @@ describe('github git http username resolution', () => {
       }),
     )
 
-    await expect(
-      resolveGitHubHttpUsername('github_pat_invalid'),
-    ).rejects.toThrowError(
-      'token cannot resolve GitHub identity for HTTPS git authentication. Ensure the token remains valid and authorized.',
-    )
+    const result = await resolveGitHubHttpUsername('github_pat_invalid')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        'token cannot resolve GitHub identity for HTTPS git authentication. Ensure the token remains valid and authorized.',
+      )
+    }
   })
 
-  it('throws error on other non-ok status', async () => {
+  it('returns error on other non-ok status', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -85,14 +95,16 @@ describe('github git http username resolution', () => {
       }),
     )
 
-    await expect(
-      resolveGitHubHttpUsername('github_pat_error'),
-    ).rejects.toThrowError(
-      'Failed to resolve GitHub identity for HTTPS git authentication (HTTP 500).',
-    )
+    const result = await resolveGitHubHttpUsername('github_pat_error')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        'Failed to resolve GitHub identity for HTTPS git authentication (HTTP 500).',
+      )
+    }
   })
 
-  it('throws error if login is missing from successful response', async () => {
+  it('returns error if login is missing from successful response', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -102,14 +114,16 @@ describe('github git http username resolution', () => {
       }),
     )
 
-    await expect(
-      resolveGitHubHttpUsername('github_pat_missing_login'),
-    ).rejects.toThrowError(
-      'GitHub identity response did not include a usable login for HTTPS git authentication.',
-    )
+    const result = await resolveGitHubHttpUsername('github_pat_missing_login')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        'GitHub identity response did not include a usable login for HTTPS git authentication.',
+      )
+    }
   })
 
-  it('throws error if login is empty from successful response', async () => {
+  it('returns error if login is empty from successful response', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -119,10 +133,12 @@ describe('github git http username resolution', () => {
       }),
     )
 
-    await expect(
-      resolveGitHubHttpUsername('github_pat_empty_login'),
-    ).rejects.toThrowError(
-      'GitHub identity response did not include a usable login for HTTPS git authentication.',
-    )
+    const result = await resolveGitHubHttpUsername('github_pat_empty_login')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        'GitHub identity response did not include a usable login for HTTPS git authentication.',
+      )
+    }
   })
 })

--- a/tests/adapters/github/release-asset-api.test.ts
+++ b/tests/adapters/github/release-asset-api.test.ts
@@ -7,7 +7,7 @@ describe('release-asset-api adapter', () => {
   })
 
   describe('fetchReleaseAsset', () => {
-    it('throws on invalid JSON metadata', async () => {
+    it('returns error on invalid JSON metadata', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -17,20 +17,25 @@ describe('release-asset-api adapter', () => {
         }),
       )
 
-      await expect(
-        fetchReleaseAsset({
-          token: 'token',
-          releaseRepository: 'owner/repo',
-          tagVersion: 'v1.0.0',
-          candidates: ['jlo-linux-x86_64'],
-        }),
-      ).rejects.toThrow(/Invalid release metadata structure/i)
+      const result = await fetchReleaseAsset({
+        token: 'token',
+        releaseRepository: 'owner/repo',
+        tagVersion: 'v1.0.0',
+        candidates: ['jlo-linux-x86_64'],
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toMatch(
+          /Invalid release metadata structure/i,
+        )
+      }
     })
 
     it.each([
       { status: 401, description: 'unauthorized' },
       { status: 403, description: 'forbidden' },
-    ])('throws error on $status $description metadata fetch', async ({
+    ])('returns error on $status $description metadata fetch', async ({
       status,
     }) => {
       vi.stubGlobal(
@@ -41,19 +46,22 @@ describe('release-asset-api adapter', () => {
         }),
       )
 
-      await expect(
-        fetchReleaseAsset({
-          token: 'secret',
-          releaseRepository: 'owner/repo',
-          tagVersion: 'v1.0.0',
-          candidates: ['asset-linux'],
-        }),
-      ).rejects.toThrowError(
-        "token cannot access release metadata in 'owner/repo'. Ensure contents:read and organization SSO authorization.",
-      )
+      const result = await fetchReleaseAsset({
+        token: 'secret',
+        releaseRepository: 'owner/repo',
+        tagVersion: 'v1.0.0',
+        candidates: ['asset-linux'],
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          "token cannot access release metadata in 'owner/repo'. Ensure contents:read and organization SSO authorization.",
+        )
+      }
     })
 
-    it('throws error on 404 not found metadata fetch', async () => {
+    it('returns error on 404 not found metadata fetch', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -62,19 +70,22 @@ describe('release-asset-api adapter', () => {
         }),
       )
 
-      await expect(
-        fetchReleaseAsset({
-          token: 'secret',
-          releaseRepository: 'owner/repo',
-          tagVersion: 'v1.0.0',
-          candidates: ['asset-linux'],
-        }),
-      ).rejects.toThrowError(
-        "Release 'v1.0.0' was not found (or is inaccessible) in 'owner/repo'.",
-      )
+      const result = await fetchReleaseAsset({
+        token: 'secret',
+        releaseRepository: 'owner/repo',
+        tagVersion: 'v1.0.0',
+        candidates: ['asset-linux'],
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          "Release 'v1.0.0' was not found (or is inaccessible) in 'owner/repo'.",
+        )
+      }
     })
 
-    it('throws error on other non-ok metadata fetch', async () => {
+    it('returns error on other non-ok metadata fetch', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -83,19 +94,22 @@ describe('release-asset-api adapter', () => {
         }),
       )
 
-      await expect(
-        fetchReleaseAsset({
-          token: 'secret',
-          releaseRepository: 'owner/repo',
-          tagVersion: 'v1.0.0',
-          candidates: ['asset-linux'],
-        }),
-      ).rejects.toThrowError(
-        "Failed to query release metadata for 'v1.0.0' in 'owner/repo' (HTTP 500).",
-      )
+      const result = await fetchReleaseAsset({
+        token: 'secret',
+        releaseRepository: 'owner/repo',
+        tagVersion: 'v1.0.0',
+        candidates: ['asset-linux'],
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          "Failed to query release metadata for 'v1.0.0' in 'owner/repo' (HTTP 500).",
+        )
+      }
     })
 
-    it('throws error if no candidate matches', async () => {
+    it('returns error if no candidate matches', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -110,19 +124,22 @@ describe('release-asset-api adapter', () => {
         }),
       )
 
-      await expect(
-        fetchReleaseAsset({
-          token: 'secret',
-          releaseRepository: 'owner/repo',
-          tagVersion: 'v1.0.0',
-          candidates: ['asset-linux', 'fallback-linux'],
-        }),
-      ).rejects.toThrowError(
-        "No matching release asset for asset-linux, fallback-linux in 'owner/repo'.",
-      )
+      const result = await fetchReleaseAsset({
+        token: 'secret',
+        releaseRepository: 'owner/repo',
+        tagVersion: 'v1.0.0',
+        candidates: ['asset-linux', 'fallback-linux'],
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          "No matching release asset for asset-linux, fallback-linux in 'owner/repo'.",
+        )
+      }
     })
 
-    it('throws error if asset download fails', async () => {
+    it('returns error if asset download fails', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockImplementation(async (url) => {
@@ -147,19 +164,22 @@ describe('release-asset-api adapter', () => {
         }),
       )
 
-      await expect(
-        fetchReleaseAsset({
-          token: 'secret',
-          releaseRepository: 'owner/repo',
-          tagVersion: 'v1.0.0',
-          candidates: ['asset-linux'],
-        }),
-      ).rejects.toThrowError(
-        "Failed to download release asset 'asset-linux' from 'owner/repo' (HTTP 500).",
-      )
+      const result = await fetchReleaseAsset({
+        token: 'secret',
+        releaseRepository: 'owner/repo',
+        tagVersion: 'v1.0.0',
+        candidates: ['asset-linux'],
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          "Failed to download release asset 'asset-linux' from 'owner/repo' (HTTP 500).",
+        )
+      }
     })
 
-    it('succeeds and returns matched asset on valid response', async () => {
+    it('succeeds and returns ok result on valid response', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockImplementation(async (url) => {
@@ -195,8 +215,11 @@ describe('release-asset-api adapter', () => {
         candidates: ['asset-linux', 'fallback-linux'],
       })
 
-      expect(result.name).toBe('fallback-linux')
-      expect(result.contents).toEqual(Buffer.from([1, 2, 3]))
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value.name).toBe('fallback-linux')
+        expect(result.value.contents).toEqual(Buffer.from([1, 2, 3]))
+      }
 
       expect(fetch).toHaveBeenCalledTimes(2)
       expect(fetch).toHaveBeenNthCalledWith(

--- a/tests/adapters/process/github-source-git.test.ts
+++ b/tests/adapters/process/github-source-git.test.ts
@@ -31,42 +31,50 @@ describe('github-source-git adapter', () => {
   })
 
   describe('cloneGitHubBranch', () => {
-    it('throws error if clone fails due to stderr', () => {
+    it('returns error if clone fails due to stderr', () => {
       vi.mocked(childProcess.spawnSync).mockReturnValue({
         status: 1,
         stderr: 'fatal: Authentication failed',
         stdout: '',
       } as ReturnType<typeof childProcess.spawnSync>)
 
-      expect(() =>
-        cloneGitHubBranch({
-          repository: 'owner/repo',
-          branch: 'main',
-          destination: '/dest',
-          token: 'secret',
-          username: 'jlo-bot',
-        }),
-      ).toThrowError(
-        'Failed to clone owner/repo@main: fatal: Authentication failed',
-      )
+      const result = cloneGitHubBranch({
+        repository: 'owner/repo',
+        branch: 'main',
+        destination: '/dest',
+        token: 'secret',
+        username: 'jlo-bot',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          'Failed to clone owner/repo@main: fatal: Authentication failed',
+        )
+      }
     })
 
-    it('throws error if clone fails and stderr is empty but stdout exists', () => {
+    it('returns error if clone fails and stderr is empty but stdout exists', () => {
       vi.mocked(childProcess.spawnSync).mockReturnValue({
         status: 1,
         stderr: '  ',
         stdout: 'Error message in stdout',
       } as ReturnType<typeof childProcess.spawnSync>)
 
-      expect(() =>
-        cloneGitHubBranch({
-          repository: 'owner/repo',
-          branch: 'main',
-          destination: '/dest',
-          token: 'secret',
-          username: 'jlo-bot',
-        }),
-      ).toThrowError('Failed to clone owner/repo@main: Error message in stdout')
+      const result = cloneGitHubBranch({
+        repository: 'owner/repo',
+        branch: 'main',
+        destination: '/dest',
+        token: 'secret',
+        username: 'jlo-bot',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          'Failed to clone owner/repo@main: Error message in stdout',
+        )
+      }
     })
 
     it('succeeds on successful clone', () => {
@@ -102,28 +110,36 @@ describe('github-source-git adapter', () => {
   })
 
   describe('resolveGitWorktreeHeadSha', () => {
-    it('throws error if command fails', () => {
+    it('returns error if command fails', () => {
       vi.mocked(childProcess.spawnSync).mockReturnValue({
         status: 1,
         stderr: 'Not a git repository',
         stdout: '',
       } as ReturnType<typeof childProcess.spawnSync>)
 
-      expect(() => resolveGitWorktreeHeadSha({ cwd: '/src' })).toThrowError(
-        'Failed to resolve cloned source head SHA: Not a git repository',
-      )
+      const result = resolveGitWorktreeHeadSha({ cwd: '/src' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          'Failed to resolve cloned source head SHA: Not a git repository',
+        )
+      }
     })
 
-    it('throws error if sha format is invalid', () => {
+    it('returns error if sha format is invalid', () => {
       vi.mocked(childProcess.spawnSync).mockReturnValue({
         status: 0,
         stdout: 'shortsha',
         stderr: '',
       } as ReturnType<typeof childProcess.spawnSync>)
 
-      expect(() => resolveGitWorktreeHeadSha({ cwd: '/src' })).toThrowError(
-        'Failed to resolve cloned source head SHA.',
-      )
+      const result = resolveGitWorktreeHeadSha({ cwd: '/src' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          'Failed to resolve cloned source head SHA.',
+        )
+      }
     })
 
     it('returns sha if format is valid', () => {
@@ -134,30 +150,37 @@ describe('github-source-git adapter', () => {
         stderr: '',
       } as ReturnType<typeof childProcess.spawnSync>)
 
-      expect(resolveGitWorktreeHeadSha({ cwd: '/src' })).toBe(sha)
+      const result = resolveGitWorktreeHeadSha({ cwd: '/src' })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toBe(sha)
+      }
     })
   })
 
   describe('updateGitHubSubmodules', () => {
-    it('throws error if sync fails', () => {
+    it('returns error if sync fails', () => {
       vi.mocked(childProcess.spawnSync).mockReturnValueOnce({
         status: 1,
         stderr: 'fatal: no submodule mapping found',
         stdout: '',
       } as ReturnType<typeof childProcess.spawnSync>)
 
-      expect(() =>
-        updateGitHubSubmodules({
-          cwd: '/src',
-          token: 'secret',
-          username: 'jlo-bot',
-        }),
-      ).toThrowError(
-        'Failed to sync git submodule configuration for source build: fatal: no submodule mapping found',
-      )
+      const result = updateGitHubSubmodules({
+        cwd: '/src',
+        token: 'secret',
+        username: 'jlo-bot',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          'Failed to sync git submodule configuration for source build: fatal: no submodule mapping found',
+        )
+      }
     })
 
-    it('throws error if update fails', () => {
+    it('returns error if update fails', () => {
       vi.mocked(childProcess.spawnSync)
         .mockReturnValueOnce({
           status: 0,
@@ -170,15 +193,18 @@ describe('github-source-git adapter', () => {
           stdout: '',
         } as ReturnType<typeof childProcess.spawnSync>)
 
-      expect(() =>
-        updateGitHubSubmodules({
-          cwd: '/src',
-          token: 'secret',
-          username: 'jlo-bot',
-        }),
-      ).toThrowError(
-        'Failed to fetch git submodules for source build: fatal: update failed',
-      )
+      const result = updateGitHubSubmodules({
+        cwd: '/src',
+        token: 'secret',
+        username: 'jlo-bot',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          'Failed to fetch git submodules for source build: fatal: update failed',
+        )
+      }
     })
 
     it('succeeds on sync and update', () => {

--- a/tests/adapters/process/github-source-git.test.ts
+++ b/tests/adapters/process/github-source-git.test.ts
@@ -241,4 +241,28 @@ describe('github-source-git adapter', () => {
       )
     })
   })
+
+  describe('runGitHubCommand error handling', () => {
+    it('returns error if spawnSync itself fails (e.g. binary not found)', () => {
+      vi.mocked(childProcess.spawnSync).mockReturnValue({
+        error: new Error('spawn git ENOENT'),
+        status: null,
+      } as ReturnType<typeof childProcess.spawnSync>)
+
+      const result = cloneGitHubBranch({
+        repository: 'owner/repo',
+        branch: 'main',
+        destination: '/dest',
+        token: 'secret',
+        username: 'jlo-bot',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe(
+          'Failed to clone owner/repo@main: spawn git ENOENT',
+        )
+      }
+    })
+  })
 })

--- a/tests/app/install-main-source.test.ts
+++ b/tests/app/install-main-source.test.ts
@@ -95,11 +95,14 @@ describe('app install main-source orchestration', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    resolveGitHubHttpUsername.mockResolvedValue('jlo-user')
+    resolveGitHubHttpUsername.mockResolvedValue({ ok: true, value: 'jlo-user' })
     commandExists.mockReturnValue(true)
-    resolveGitWorktreeHeadSha.mockReturnValue(
-      '0123456789abcdef0123456789abcdef01234567',
-    )
+    cloneGitHubBranch.mockReturnValue({ ok: true, value: undefined })
+    updateGitHubSubmodules.mockReturnValue({ ok: true, value: undefined })
+    resolveGitWorktreeHeadSha.mockReturnValue({
+      ok: true,
+      value: '0123456789abcdef0123456789abcdef01234567',
+    })
     detectPlatformTuple.mockReturnValue({ os: 'linux', arch: 'x86_64' })
     resolvePlatformCacheDirectory.mockReturnValue('/cache/linux-x86_64')
     ensureInstallDirectory.mockReturnValue(
@@ -160,8 +163,9 @@ describe('app install main-source orchestration', () => {
 
   it('fails and cleans up temp directory if submodule update fails', async () => {
     existsSync.mockReturnValue(false)
-    updateGitHubSubmodules.mockImplementation(() => {
-      throw new Error('Git fetch failed')
+    updateGitHubSubmodules.mockReturnValue({
+      ok: false,
+      error: new Error('Git fetch failed'),
     })
 
     await expect(
@@ -210,24 +214,5 @@ describe('app install main-source orchestration', () => {
         tempDirectory: '/tmp',
       }),
     ).rejects.toThrow('main install requires git on PATH.')
-  })
-
-  it('safely wraps non-Error strings thrown during submodule updates', async () => {
-    existsSync.mockReturnValue(false)
-    updateGitHubSubmodules.mockImplementation(() => {
-      throw 'fatal: repository not found'
-    })
-
-    await expect(
-      installMainSource({
-        token: 'token',
-        submoduleToken: 'submodule-token',
-        allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
-      }),
-    ).rejects.toThrow(
-      /Failed to fetch required git submodules.*: fatal: repository not found/,
-    )
   })
 })

--- a/tests/app/install-release.test.ts
+++ b/tests/app/install-release.test.ts
@@ -117,8 +117,11 @@ describe('app install release orchestration', () => {
     tmpdir.mockReturnValue(MOCK_TMP_DIR)
     mkdtempSync.mockReturnValue(MOCK_DOWNLOAD_PATH)
     fetchReleaseAsset.mockResolvedValue({
-      name: 'jlo-linux-x86_64',
-      contents: Buffer.from(''),
+      ok: true,
+      value: {
+        name: 'jlo-linux-x86_64',
+        contents: Buffer.from(''),
+      },
     })
     statSync.mockReturnValue({ size: 0 })
 
@@ -151,8 +154,11 @@ describe('app install release orchestration', () => {
     tmpdir.mockReturnValue(MOCK_TMP_DIR)
     mkdtempSync.mockReturnValue(MOCK_DOWNLOAD_PATH)
     fetchReleaseAsset.mockResolvedValue({
-      name: 'jlo-linux-x86_64',
-      contents: Buffer.from('binary-data'),
+      ok: true,
+      value: {
+        name: 'jlo-linux-x86_64',
+        contents: Buffer.from('binary-data'),
+      },
     })
     statSync.mockReturnValue({ size: 100 })
     ensureExecutablePermissions.mockImplementation(() => {


### PR DESCRIPTION
Refactors application boundaries to use a explicit discriminated union `Result` type instead of blindly throwing native errors to improve error handling context, stack traces, and overall reliability.

Changes:
* Creates `src/domain/result.ts`.
* Refactors `src/adapters/github/release-asset-api.ts`.
* Refactors `src/adapters/process/github-source-git.ts`.
* Refactors `src/adapters/github/github-git-http-username.ts`.
* Refactors `install-main-source.ts` and `install-release.ts` to unwrap results.
* Updates `index.ts` to log errors robustly.
* Updates all tests.

---
*PR created automatically by Jules for task [17461296895871978121](https://jules.google.com/task/17461296895871978121) started by @akitorahayashi*