### PR TITLE
test: refactor app tests to assert on filesystem over spies

### DIFF
--- a/tests/app/install-main-source.test.ts
+++ b/tests/app/install-main-source.test.ts
@@ -1,15 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type { SpawnSyncReturns } from 'node:child_process'
 
-const { info, addPath, resolveGitHubHttpUsername, spawnSync } = vi.hoisted(() => ({
-  info: vi.fn(),
-  addPath: vi.fn(),
-  resolveGitHubHttpUsername: vi.fn(),
-  spawnSync: vi.fn(),
-}))
+const { info, addPath, resolveGitHubHttpUsername, spawnSync } = vi.hoisted(
+  () => ({
+    info: vi.fn(),
+    addPath: vi.fn(),
+    resolveGitHubHttpUsername: vi.fn(),
+    spawnSync: vi.fn(),
+  }),
+)
 
 vi.mock('@actions/core', () => ({
   info,
@@ -21,7 +30,10 @@ vi.mock('../../src/adapters/github/github-git-http-username', () => ({
 }))
 
 vi.mock('node:child_process', async () => {
-  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+  const actual =
+    await vi.importActual<typeof import('node:child_process')>(
+      'node:child_process',
+    )
   return {
     ...actual,
     spawnSync,
@@ -56,32 +68,64 @@ describe('app install main-source orchestration', () => {
     resolveGitHubHttpUsername.mockResolvedValue('jlo-user')
 
     // Base mock for spawnSync covering git, cargo, and binary execution
-    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
-      if (command === 'git') {
-        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
-        if (args.includes('clone')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-        if (args.includes('rev-parse') && args.includes('HEAD')) return { status: 0, stdout: mockSha + '\n', stderr: '' } as SpawnSyncReturns<string>
-        if (args.includes('submodule')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-      }
-
-      if (command === 'cargo') {
-        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
-        if (args.includes('build')) {
-          const targetDir = options?.env?.CARGO_TARGET_DIR || join(options?.cwd, 'target')
-          const binaryPath = join(targetDir, 'release', 'jlo')
-          mkdirSync(join(targetDir, 'release'), { recursive: true })
-          writeFileSync(binaryPath, 'mock-binary')
-          return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+    spawnSync.mockImplementation(
+      (command: string, args: string[], options: any) => {
+        if (command === 'git') {
+          if (args.includes('--version'))
+            return { status: 0 } as SpawnSyncReturns<string>
+          if (args.includes('clone'))
+            return {
+              status: 0,
+              stdout: '',
+              stderr: '',
+            } as SpawnSyncReturns<string>
+          if (args.includes('rev-parse') && args.includes('HEAD'))
+            return {
+              status: 0,
+              stdout: mockSha + '\n',
+              stderr: '',
+            } as SpawnSyncReturns<string>
+          if (args.includes('submodule'))
+            return {
+              status: 0,
+              stdout: '',
+              stderr: '',
+            } as SpawnSyncReturns<string>
         }
-      }
 
-      // Check if it's the jlo binary being executed
-      if (command.endsWith('jlo') && args.includes('--version')) {
-        return { status: 0, stdout: 'jlo main', stderr: '' } as SpawnSyncReturns<string>
-      }
+        if (command === 'cargo') {
+          if (args.includes('--version'))
+            return { status: 0 } as SpawnSyncReturns<string>
+          if (args.includes('build')) {
+            const targetDir =
+              options?.env?.CARGO_TARGET_DIR || join(options?.cwd, 'target')
+            const binaryPath = join(targetDir, 'release', 'jlo')
+            mkdirSync(join(targetDir, 'release'), { recursive: true })
+            writeFileSync(binaryPath, 'mock-binary')
+            return {
+              status: 0,
+              stdout: '',
+              stderr: '',
+            } as SpawnSyncReturns<string>
+          }
+        }
 
-      return { status: 1, stdout: '', stderr: `Command not found or handled: ${command} ${args.join(' ')}` } as SpawnSyncReturns<string>
-    })
+        // Check if it's the jlo binary being executed
+        if (command.endsWith('jlo') && args.includes('--version')) {
+          return {
+            status: 0,
+            stdout: 'jlo main',
+            stderr: '',
+          } as SpawnSyncReturns<string>
+        }
+
+        return {
+          status: 1,
+          stdout: '',
+          stderr: `Command not found or handled: ${command} ${args.join(' ')}`,
+        } as SpawnSyncReturns<string>
+      },
+    )
   })
 
   afterEach(() => {
@@ -106,8 +150,16 @@ describe('app install main-source orchestration', () => {
 
     // Verify it didn't call cargo build or submodule updates
     const spawnCalls = spawnSync.mock.calls
-    expect(spawnCalls.some(call => call[0] === 'cargo' && call[1].includes('build'))).toBe(false)
-    expect(spawnCalls.some(call => call[0] === 'git' && call[1].includes('submodule'))).toBe(false)
+    expect(
+      spawnCalls.some(
+        (call) => call[0] === 'cargo' && call[1].includes('build'),
+      ),
+    ).toBe(false)
+    expect(
+      spawnCalls.some(
+        (call) => call[0] === 'git' && call[1].includes('submodule'),
+      ),
+    ).toBe(false)
 
     expect(info).toHaveBeenCalledWith(
       `jlo main@${shortSha} already cached; skipping build.`,
@@ -126,9 +178,27 @@ describe('app install main-source orchestration', () => {
     })
 
     const spawnCalls = spawnSync.mock.calls
-    expect(spawnCalls.some(call => call[0] === 'git' && call[1].includes('submodule') && call[1].includes('sync'))).toBe(true)
-    expect(spawnCalls.some(call => call[0] === 'git' && call[1].includes('submodule') && call[1].includes('update'))).toBe(true)
-    expect(spawnCalls.some(call => call[0] === 'cargo' && call[1].includes('build'))).toBe(true)
+    expect(
+      spawnCalls.some(
+        (call) =>
+          call[0] === 'git' &&
+          call[1].includes('submodule') &&
+          call[1].includes('sync'),
+      ),
+    ).toBe(true)
+    expect(
+      spawnCalls.some(
+        (call) =>
+          call[0] === 'git' &&
+          call[1].includes('submodule') &&
+          call[1].includes('update'),
+      ),
+    ).toBe(true)
+    expect(
+      spawnCalls.some(
+        (call) => call[0] === 'cargo' && call[1].includes('build'),
+      ),
+    ).toBe(true)
 
     expect(info).toHaveBeenCalledWith(
       'Using submodule_token for required submodule fetch.',
@@ -154,21 +224,39 @@ describe('app install main-source orchestration', () => {
   })
 
   it('fails and cleans up temp directory if submodule update fails', async () => {
-    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
-      if (command === 'git' && args.includes('submodule')) {
-        return { status: 1, stdout: '', stderr: 'Git fetch failed' } as SpawnSyncReturns<string>
-      }
+    spawnSync.mockImplementation(
+      (command: string, args: string[], options: any) => {
+        if (command === 'git' && args.includes('submodule')) {
+          return {
+            status: 1,
+            stdout: '',
+            stderr: 'Git fetch failed',
+          } as SpawnSyncReturns<string>
+        }
 
-      // Default success for others to reach the submodule call
-      if (command === 'git') {
-        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
-        if (args.includes('clone')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-        if (args.includes('rev-parse') && args.includes('HEAD')) return { status: 0, stdout: mockSha + '\n', stderr: '' } as SpawnSyncReturns<string>
-      }
-      if (command === 'cargo' && args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+        // Default success for others to reach the submodule call
+        if (command === 'git') {
+          if (args.includes('--version'))
+            return { status: 0 } as SpawnSyncReturns<string>
+          if (args.includes('clone'))
+            return {
+              status: 0,
+              stdout: '',
+              stderr: '',
+            } as SpawnSyncReturns<string>
+          if (args.includes('rev-parse') && args.includes('HEAD'))
+            return {
+              status: 0,
+              stdout: mockSha + '\n',
+              stderr: '',
+            } as SpawnSyncReturns<string>
+        }
+        if (command === 'cargo' && args.includes('--version'))
+          return { status: 0 } as SpawnSyncReturns<string>
 
-      return { status: 1, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-    })
+        return { status: 1, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+      },
+    )
 
     await expect(
       installMainSource({
@@ -188,12 +276,18 @@ describe('app install main-source orchestration', () => {
   })
 
   it('fails when cargo is not installed on PATH', async () => {
-    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
-      if (command === 'cargo' && args.includes('--version')) {
-        return { status: 1, stdout: '', stderr: 'command not found' } as SpawnSyncReturns<string>
-      }
-      return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-    })
+    spawnSync.mockImplementation(
+      (command: string, args: string[], options: any) => {
+        if (command === 'cargo' && args.includes('--version')) {
+          return {
+            status: 1,
+            stdout: '',
+            stderr: 'command not found',
+          } as SpawnSyncReturns<string>
+        }
+        return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+      },
+    )
 
     await expect(
       installMainSource({
@@ -209,15 +303,25 @@ describe('app install main-source orchestration', () => {
   })
 
   it('fails when git is not installed on PATH', async () => {
-    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
-      if (command === 'cargo' && args.includes('--version')) {
+    spawnSync.mockImplementation(
+      (command: string, args: string[], options: any) => {
+        if (command === 'cargo' && args.includes('--version')) {
+          return {
+            status: 0,
+            stdout: '',
+            stderr: '',
+          } as SpawnSyncReturns<string>
+        }
+        if (command === 'git' && args.includes('--version')) {
+          return {
+            status: 1,
+            stdout: '',
+            stderr: 'command not found',
+          } as SpawnSyncReturns<string>
+        }
         return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-      }
-      if (command === 'git' && args.includes('--version')) {
-        return { status: 1, stdout: '', stderr: 'command not found' } as SpawnSyncReturns<string>
-      }
-      return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-    })
+      },
+    )
 
     await expect(
       installMainSource({
@@ -231,20 +335,38 @@ describe('app install main-source orchestration', () => {
   })
 
   it('safely wraps non-Error strings thrown during submodule updates', async () => {
-    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
-      if (command === 'git' && args.includes('submodule')) {
-        return { status: 1, stdout: '', stderr: 'fatal: repository not found' } as SpawnSyncReturns<string>
-      }
+    spawnSync.mockImplementation(
+      (command: string, args: string[], options: any) => {
+        if (command === 'git' && args.includes('submodule')) {
+          return {
+            status: 1,
+            stdout: '',
+            stderr: 'fatal: repository not found',
+          } as SpawnSyncReturns<string>
+        }
 
-      if (command === 'git') {
-        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
-        if (args.includes('clone')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-        if (args.includes('rev-parse') && args.includes('HEAD')) return { status: 0, stdout: mockSha + '\n', stderr: '' } as SpawnSyncReturns<string>
-      }
-      if (command === 'cargo' && args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+        if (command === 'git') {
+          if (args.includes('--version'))
+            return { status: 0 } as SpawnSyncReturns<string>
+          if (args.includes('clone'))
+            return {
+              status: 0,
+              stdout: '',
+              stderr: '',
+            } as SpawnSyncReturns<string>
+          if (args.includes('rev-parse') && args.includes('HEAD'))
+            return {
+              status: 0,
+              stdout: mockSha + '\n',
+              stderr: '',
+            } as SpawnSyncReturns<string>
+        }
+        if (command === 'cargo' && args.includes('--version'))
+          return { status: 0 } as SpawnSyncReturns<string>
 
-      return { status: 1, stdout: '', stderr: '' } as SpawnSyncReturns<string>
-    })
+        return { status: 1, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+      },
+    )
 
     await expect(
       installMainSource({

--- a/tests/app/install-main-source.test.ts
+++ b/tests/app/install-main-source.test.ts
@@ -1,150 +1,145 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { SpawnSyncReturns } from 'node:child_process'
 
-const {
-  info,
-  existsSync,
-  mkdtempSync,
-  rmSync,
-  resolveGitHubHttpUsername,
-  commandExists,
-  cloneGitHubBranch,
-  resolveGitWorktreeHeadSha,
-  updateGitHubSubmodules,
-  detectPlatformTuple,
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  installBinaryOnPath,
-  pruneSiblingInstallDirectories,
-  detectBinaryVersion,
-  buildCargoRelease,
-  copyExecutableBinary,
-  tmpdir,
-} = vi.hoisted(() => ({
+const { info, addPath, resolveGitHubHttpUsername, spawnSync } = vi.hoisted(() => ({
   info: vi.fn(),
-  existsSync: vi.fn(),
-  mkdtempSync: vi.fn(),
-  rmSync: vi.fn(),
+  addPath: vi.fn(),
   resolveGitHubHttpUsername: vi.fn(),
-  commandExists: vi.fn(),
-  cloneGitHubBranch: vi.fn(),
-  resolveGitWorktreeHeadSha: vi.fn(),
-  updateGitHubSubmodules: vi.fn(),
-  detectPlatformTuple: vi.fn(),
-  resolvePlatformCacheDirectory: vi.fn(),
-  ensureInstallDirectory: vi.fn(),
-  installBinaryOnPath: vi.fn(),
-  pruneSiblingInstallDirectories: vi.fn(),
-  detectBinaryVersion: vi.fn(),
-  buildCargoRelease: vi.fn(),
-  copyExecutableBinary: vi.fn(),
-  tmpdir: vi.fn(),
+  spawnSync: vi.fn(),
 }))
 
 vi.mock('@actions/core', () => ({
   info,
-}))
-
-vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return {
-    ...actual,
-    existsSync,
-    mkdtempSync,
-    rmSync,
-  }
-})
-
-vi.mock('node:os', () => ({
-  tmpdir,
+  addPath,
 }))
 
 vi.mock('../../src/adapters/github/github-git-http-username', () => ({
   resolveGitHubHttpUsername,
 }))
 
-vi.mock('../../src/adapters/process/github-source-git', () => ({
-  commandExists,
-  cloneGitHubBranch,
-  resolveGitWorktreeHeadSha,
-  updateGitHubSubmodules,
-}))
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+  return {
+    ...actual,
+    spawnSync,
+  }
+})
 
-vi.mock('../../src/domain/platform', () => ({
-  detectPlatformTuple,
-}))
-
-vi.mock('../../src/adapters/cache/binary-install-cache', () => ({
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  installBinaryOnPath,
-  pruneSiblingInstallDirectories,
-  detectBinaryVersion,
-  copyExecutableBinary,
-}))
-
-vi.mock('../../src/adapters/process/cargo-build', () => ({
-  buildCargoRelease,
-}))
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os')
+  return {
+    ...actual,
+    platform: () => 'linux',
+    arch: () => 'x64', // Which maps to x86_64 in our logic
+  }
+})
 
 import { installMainSource } from '../../src/app/install-main-source'
 
 describe('app install main-source orchestration', () => {
-  const MOCK_TMP_DIR = '/tmp'
-  const MOCK_CLONE_PATH = '/tmp/setup-jlo-main-1234'
-  const MOCK_BUILD_PATH = '/tmp/jlo'
+  let cacheRoot: string
+  let tempDirectory: string
+
+  const mockSha = '0123456789abcdef0123456789abcdef01234567'
 
   beforeEach(() => {
     vi.clearAllMocks()
+
+    // Set up real temp directories for the tests
+    const baseTemp = tmpdir()
+    cacheRoot = mkdtempSync(join(baseTemp, 'setup-jlo-cache-'))
+    tempDirectory = mkdtempSync(join(baseTemp, 'setup-jlo-tmp-'))
+
     resolveGitHubHttpUsername.mockResolvedValue('jlo-user')
-    commandExists.mockReturnValue(true)
-    resolveGitWorktreeHeadSha.mockReturnValue(
-      '0123456789abcdef0123456789abcdef01234567',
-    )
-    detectPlatformTuple.mockReturnValue({ os: 'linux', arch: 'x86_64' })
-    resolvePlatformCacheDirectory.mockReturnValue('/cache/linux-x86_64')
-    ensureInstallDirectory.mockReturnValue(
-      '/cache/linux-x86_64/main-0123456789ab',
-    )
-    existsSync.mockReturnValue(true)
-    detectBinaryVersion.mockReturnValue('jlo main')
-    tmpdir.mockReturnValue(MOCK_TMP_DIR)
-    mkdtempSync.mockReturnValue(MOCK_CLONE_PATH)
+
+    // Base mock for spawnSync covering git, cargo, and binary execution
+    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
+      if (command === 'git') {
+        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+        if (args.includes('clone')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+        if (args.includes('rev-parse') && args.includes('HEAD')) return { status: 0, stdout: mockSha + '\n', stderr: '' } as SpawnSyncReturns<string>
+        if (args.includes('submodule')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+      }
+
+      if (command === 'cargo') {
+        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+        if (args.includes('build')) {
+          const targetDir = options?.env?.CARGO_TARGET_DIR || join(options?.cwd, 'target')
+          const binaryPath = join(targetDir, 'release', 'jlo')
+          mkdirSync(join(targetDir, 'release'), { recursive: true })
+          writeFileSync(binaryPath, 'mock-binary')
+          return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+        }
+      }
+
+      // Check if it's the jlo binary being executed
+      if (command.endsWith('jlo') && args.includes('--version')) {
+        return { status: 0, stdout: 'jlo main', stderr: '' } as SpawnSyncReturns<string>
+      }
+
+      return { status: 1, stdout: '', stderr: `Command not found or handled: ${command} ${args.join(' ')}` } as SpawnSyncReturns<string>
+    })
+  })
+
+  afterEach(() => {
+    rmSync(cacheRoot, { recursive: true, force: true })
+    rmSync(tempDirectory, { recursive: true, force: true })
   })
 
   it('reuses cached main binary and skips build', async () => {
+    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const shortSha = mockSha.slice(0, 12)
+    const installDir = join(platformDir, `main-${shortSha}`)
+    mkdirSync(installDir, { recursive: true })
+    writeFileSync(join(installDir, 'jlo'), 'cached-binary')
+
     await installMainSource({
       token: 'token',
       submoduleToken: 'submodule-token',
       allowDarwinX8664Fallback: false,
-      cacheRoot: '/cache',
-      tempDirectory: '/tmp',
+      cacheRoot,
+      tempDirectory,
     })
 
-    expect(updateGitHubSubmodules).not.toHaveBeenCalled()
-    expect(buildCargoRelease).not.toHaveBeenCalled()
-    expect(copyExecutableBinary).not.toHaveBeenCalled()
+    // Verify it didn't call cargo build or submodule updates
+    const spawnCalls = spawnSync.mock.calls
+    expect(spawnCalls.some(call => call[0] === 'cargo' && call[1].includes('build'))).toBe(false)
+    expect(spawnCalls.some(call => call[0] === 'git' && call[1].includes('submodule'))).toBe(false)
+
     expect(info).toHaveBeenCalledWith(
-      'jlo main@0123456789ab already cached; skipping build.',
+      `jlo main@${shortSha} already cached; skipping build.`,
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo main')
+    expect(addPath).toHaveBeenCalledWith(installDir)
   })
 
   it('fetches required submodules with submodule token', async () => {
-    existsSync.mockReturnValue(false)
-    buildCargoRelease.mockReturnValue(MOCK_BUILD_PATH)
-
     await installMainSource({
       token: 'token',
       submoduleToken: 'submodule-token',
       allowDarwinX8664Fallback: false,
-      cacheRoot: '/cache',
-      tempDirectory: '/tmp',
+      cacheRoot,
+      tempDirectory,
     })
+
+    const spawnCalls = spawnSync.mock.calls
+    expect(spawnCalls.some(call => call[0] === 'git' && call[1].includes('submodule') && call[1].includes('sync'))).toBe(true)
+    expect(spawnCalls.some(call => call[0] === 'git' && call[1].includes('submodule') && call[1].includes('update'))).toBe(true)
+    expect(spawnCalls.some(call => call[0] === 'cargo' && call[1].includes('build'))).toBe(true)
 
     expect(info).toHaveBeenCalledWith(
       'Using submodule_token for required submodule fetch.',
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo main')
+
+    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const shortSha = mockSha.slice(0, 12)
+    const installDir = join(platformDir, `main-${shortSha}`)
+    expect(existsSync(join(installDir, 'jlo'))).toBe(true)
+    expect(addPath).toHaveBeenCalledWith(installDir)
   })
 
   it('fails when main install omits submodule token', async () => {
@@ -152,16 +147,27 @@ describe('app install main-source orchestration', () => {
       installMainSource({
         token: 'token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot,
+        tempDirectory,
       }),
     ).rejects.toThrow('main install requires submodule_token.')
   })
 
   it('fails and cleans up temp directory if submodule update fails', async () => {
-    existsSync.mockReturnValue(false)
-    updateGitHubSubmodules.mockImplementation(() => {
-      throw new Error('Git fetch failed')
+    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
+      if (command === 'git' && args.includes('submodule')) {
+        return { status: 1, stdout: '', stderr: 'Git fetch failed' } as SpawnSyncReturns<string>
+      }
+
+      // Default success for others to reach the submodule call
+      if (command === 'git') {
+        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+        if (args.includes('clone')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+        if (args.includes('rev-parse') && args.includes('HEAD')) return { status: 0, stdout: mockSha + '\n', stderr: '' } as SpawnSyncReturns<string>
+      }
+      if (command === 'cargo' && args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+
+      return { status: 1, stdout: '', stderr: '' } as SpawnSyncReturns<string>
     })
 
     await expect(
@@ -169,29 +175,33 @@ describe('app install main-source orchestration', () => {
         token: 'token',
         submoduleToken: 'submodule-token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot,
+        tempDirectory,
       }),
     ).rejects.toThrow(
-      'Failed to fetch required git submodules for source build (verify submodule_token can read submodule repositories): Git fetch failed',
+      'Failed to fetch required git submodules for source build (verify submodule_token can read submodule repositories): Failed to sync git submodule configuration for source build: Git fetch failed',
     )
 
-    expect(rmSync).toHaveBeenCalledWith(MOCK_CLONE_PATH, {
-      recursive: true,
-      force: true,
-    })
+    // Verify temp directory was cleaned up
+    const tempDirContents = readdirSync(tempDirectory)
+    expect(tempDirContents.length).toBe(0)
   })
 
   it('fails when cargo is not installed on PATH', async () => {
-    commandExists.mockImplementation((cmd) => cmd !== 'cargo')
+    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
+      if (command === 'cargo' && args.includes('--version')) {
+        return { status: 1, stdout: '', stderr: 'command not found' } as SpawnSyncReturns<string>
+      }
+      return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+    })
 
     await expect(
       installMainSource({
         token: 'token',
         submoduleToken: 'submodule-token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot,
+        tempDirectory,
       }),
     ).rejects.toThrow(
       'main install requires cargo on PATH. Provision Rust toolchain on the runner.',
@@ -199,23 +209,14 @@ describe('app install main-source orchestration', () => {
   })
 
   it('fails when git is not installed on PATH', async () => {
-    commandExists.mockImplementation((cmd) => cmd !== 'git')
-
-    await expect(
-      installMainSource({
-        token: 'token',
-        submoduleToken: 'submodule-token',
-        allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
-      }),
-    ).rejects.toThrow('main install requires git on PATH.')
-  })
-
-  it('safely wraps non-Error strings thrown during submodule updates', async () => {
-    existsSync.mockReturnValue(false)
-    updateGitHubSubmodules.mockImplementation(() => {
-      throw 'fatal: repository not found'
+    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
+      if (command === 'cargo' && args.includes('--version')) {
+        return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+      }
+      if (command === 'git' && args.includes('--version')) {
+        return { status: 1, stdout: '', stderr: 'command not found' } as SpawnSyncReturns<string>
+      }
+      return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
     })
 
     await expect(
@@ -223,11 +224,38 @@ describe('app install main-source orchestration', () => {
         token: 'token',
         submoduleToken: 'submodule-token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot,
+        tempDirectory,
+      }),
+    ).rejects.toThrow('main install requires git on PATH.')
+  })
+
+  it('safely wraps non-Error strings thrown during submodule updates', async () => {
+    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
+      if (command === 'git' && args.includes('submodule')) {
+        return { status: 1, stdout: '', stderr: 'fatal: repository not found' } as SpawnSyncReturns<string>
+      }
+
+      if (command === 'git') {
+        if (args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+        if (args.includes('clone')) return { status: 0, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+        if (args.includes('rev-parse') && args.includes('HEAD')) return { status: 0, stdout: mockSha + '\n', stderr: '' } as SpawnSyncReturns<string>
+      }
+      if (command === 'cargo' && args.includes('--version')) return { status: 0 } as SpawnSyncReturns<string>
+
+      return { status: 1, stdout: '', stderr: '' } as SpawnSyncReturns<string>
+    })
+
+    await expect(
+      installMainSource({
+        token: 'token',
+        submoduleToken: 'submodule-token',
+        allowDarwinX8664Fallback: false,
+        cacheRoot,
+        tempDirectory,
       }),
     ).rejects.toThrow(
-      /Failed to fetch required git submodules.*: fatal: repository not found/,
+      /Failed to fetch required git submodules.*: Failed to sync git submodule configuration for source build: fatal: repository not found/,
     )
   })
 })

--- a/tests/app/install-main-source.test.ts
+++ b/tests/app/install-main-source.test.ts
@@ -2,23 +2,33 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
   mkdirSync,
   readdirSync,
 } from 'node:fs'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
 import type { SpawnSyncReturns } from 'node:child_process'
 
-const { info, addPath, resolveGitHubHttpUsername, spawnSync } = vi.hoisted(
-  () => ({
-    info: vi.fn(),
-    addPath: vi.fn(),
-    resolveGitHubHttpUsername: vi.fn(),
-    spawnSync: vi.fn(),
-  }),
-)
+interface MockSpawnOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+}
+
+const {
+  info,
+  addPath,
+  resolveGitHubHttpUsername,
+  spawnSync,
+  detectPlatformTuple,
+} = vi.hoisted(() => ({
+  info: vi.fn(),
+  addPath: vi.fn(),
+  resolveGitHubHttpUsername: vi.fn(),
+  spawnSync: vi.fn(),
+  detectPlatformTuple: vi.fn(() => ({ os: 'linux', arch: 'x86_64' })),
+}))
 
 vi.mock('@actions/core', () => ({
   info,
@@ -40,12 +50,13 @@ vi.mock('node:child_process', async () => {
   }
 })
 
-vi.mock('node:os', async () => {
-  const actual = await vi.importActual<typeof import('node:os')>('node:os')
+vi.mock('../../src/domain/platform', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../src/domain/platform')
+  >('../../src/domain/platform')
   return {
     ...actual,
-    platform: () => 'linux',
-    arch: () => 'x64', // Which maps to x86_64 in our logic
+    detectPlatformTuple,
   }
 })
 
@@ -54,22 +65,23 @@ import { installMainSource } from '../../src/app/install-main-source'
 describe('app install main-source orchestration', () => {
   let cacheRoot: string
   let tempDirectory: string
+  let tempRoot: string
 
   const mockSha = '0123456789abcdef0123456789abcdef01234567'
+  const platformDirName = 'linux-x86_64'
 
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // Set up real temp directories for the tests
-    const baseTemp = tmpdir()
-    cacheRoot = mkdtempSync(join(baseTemp, 'setup-jlo-cache-'))
-    tempDirectory = mkdtempSync(join(baseTemp, 'setup-jlo-tmp-'))
+    tempRoot = join(process.cwd(), '.tmp')
+    mkdirSync(tempRoot, { recursive: true })
+    cacheRoot = mkdtempSync(join(tempRoot, 'setup-jlo-cache-'))
+    tempDirectory = mkdtempSync(join(tempRoot, 'setup-jlo-tmp-'))
 
     resolveGitHubHttpUsername.mockResolvedValue('jlo-user')
 
-    // Base mock for spawnSync covering git, cargo, and binary execution
     spawnSync.mockImplementation(
-      (command: string, args: string[], options: any) => {
+      (command: string, args: string[], options?: MockSpawnOptions) => {
         if (command === 'git') {
           if (args.includes('--version'))
             return { status: 0 } as SpawnSyncReturns<string>
@@ -82,7 +94,7 @@ describe('app install main-source orchestration', () => {
           if (args.includes('rev-parse') && args.includes('HEAD'))
             return {
               status: 0,
-              stdout: mockSha + '\n',
+              stdout: `${mockSha}\n`,
               stderr: '',
             } as SpawnSyncReturns<string>
           if (args.includes('submodule'))
@@ -98,7 +110,8 @@ describe('app install main-source orchestration', () => {
             return { status: 0 } as SpawnSyncReturns<string>
           if (args.includes('build')) {
             const targetDir =
-              options?.env?.CARGO_TARGET_DIR || join(options?.cwd, 'target')
+              options?.env?.CARGO_TARGET_DIR ??
+              join(options?.cwd ?? tempDirectory, 'target')
             const binaryPath = join(targetDir, 'release', 'jlo')
             mkdirSync(join(targetDir, 'release'), { recursive: true })
             writeFileSync(binaryPath, 'mock-binary')
@@ -134,7 +147,7 @@ describe('app install main-source orchestration', () => {
   })
 
   it('reuses cached main binary and skips build', async () => {
-    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const platformDir = join(cacheRoot, platformDirName)
     const shortSha = mockSha.slice(0, 12)
     const installDir = join(platformDir, `main-${shortSha}`)
     mkdirSync(installDir, { recursive: true })
@@ -148,27 +161,16 @@ describe('app install main-source orchestration', () => {
       tempDirectory,
     })
 
-    // Verify it didn't call cargo build or submodule updates
-    const spawnCalls = spawnSync.mock.calls
-    expect(
-      spawnCalls.some(
-        (call) => call[0] === 'cargo' && call[1].includes('build'),
-      ),
-    ).toBe(false)
-    expect(
-      spawnCalls.some(
-        (call) => call[0] === 'git' && call[1].includes('submodule'),
-      ),
-    ).toBe(false)
-
     expect(info).toHaveBeenCalledWith(
       `jlo main@${shortSha} already cached; skipping build.`,
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo main')
     expect(addPath).toHaveBeenCalledWith(installDir)
+    expect(readFileSync(join(installDir, 'jlo'), 'utf8')).toBe('cached-binary')
+    expect(readdirSync(tempDirectory)).toHaveLength(0)
   })
 
-  it('fetches required submodules with submodule token', async () => {
+  it('builds and caches the main binary', async () => {
     await installMainSource({
       token: 'token',
       submoduleToken: 'submodule-token',
@@ -177,39 +179,18 @@ describe('app install main-source orchestration', () => {
       tempDirectory,
     })
 
-    const spawnCalls = spawnSync.mock.calls
-    expect(
-      spawnCalls.some(
-        (call) =>
-          call[0] === 'git' &&
-          call[1].includes('submodule') &&
-          call[1].includes('sync'),
-      ),
-    ).toBe(true)
-    expect(
-      spawnCalls.some(
-        (call) =>
-          call[0] === 'git' &&
-          call[1].includes('submodule') &&
-          call[1].includes('update'),
-      ),
-    ).toBe(true)
-    expect(
-      spawnCalls.some(
-        (call) => call[0] === 'cargo' && call[1].includes('build'),
-      ),
-    ).toBe(true)
-
     expect(info).toHaveBeenCalledWith(
       'Using submodule_token for required submodule fetch.',
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo main')
 
-    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const platformDir = join(cacheRoot, platformDirName)
     const shortSha = mockSha.slice(0, 12)
     const installDir = join(platformDir, `main-${shortSha}`)
     expect(existsSync(join(installDir, 'jlo'))).toBe(true)
+    expect(readFileSync(join(installDir, 'jlo'), 'utf8')).toBe('mock-binary')
     expect(addPath).toHaveBeenCalledWith(installDir)
+    expect(readdirSync(tempDirectory)).toHaveLength(0)
   })
 
   it('fails when main install omits submodule token', async () => {
@@ -225,7 +206,7 @@ describe('app install main-source orchestration', () => {
 
   it('fails and cleans up temp directory if submodule update fails', async () => {
     spawnSync.mockImplementation(
-      (command: string, args: string[], options: any) => {
+      (command: string, args: string[], _options?: MockSpawnOptions) => {
         if (command === 'git' && args.includes('submodule')) {
           return {
             status: 1,
@@ -247,7 +228,7 @@ describe('app install main-source orchestration', () => {
           if (args.includes('rev-parse') && args.includes('HEAD'))
             return {
               status: 0,
-              stdout: mockSha + '\n',
+              stdout: `${mockSha}\n`,
               stderr: '',
             } as SpawnSyncReturns<string>
         }
@@ -277,7 +258,7 @@ describe('app install main-source orchestration', () => {
 
   it('fails when cargo is not installed on PATH', async () => {
     spawnSync.mockImplementation(
-      (command: string, args: string[], options: any) => {
+      (command: string, args: string[], _options?: MockSpawnOptions) => {
         if (command === 'cargo' && args.includes('--version')) {
           return {
             status: 1,
@@ -304,7 +285,7 @@ describe('app install main-source orchestration', () => {
 
   it('fails when git is not installed on PATH', async () => {
     spawnSync.mockImplementation(
-      (command: string, args: string[], options: any) => {
+      (command: string, args: string[], _options?: MockSpawnOptions) => {
         if (command === 'cargo' && args.includes('--version')) {
           return {
             status: 0,
@@ -336,7 +317,7 @@ describe('app install main-source orchestration', () => {
 
   it('safely wraps non-Error strings thrown during submodule updates', async () => {
     spawnSync.mockImplementation(
-      (command: string, args: string[], options: any) => {
+      (command: string, args: string[], _options?: MockSpawnOptions) => {
         if (command === 'git' && args.includes('submodule')) {
           return {
             status: 1,
@@ -357,7 +338,7 @@ describe('app install main-source orchestration', () => {
           if (args.includes('rev-parse') && args.includes('HEAD'))
             return {
               status: 0,
-              stdout: mockSha + '\n',
+              stdout: `${mockSha}\n`,
               stderr: '',
             } as SpawnSyncReturns<string>
         }

--- a/tests/app/install-release.test.ts
+++ b/tests/app/install-release.test.ts
@@ -1,16 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync, mkdirSync, chmodSync, readdirSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+  readdirSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type { SpawnSyncReturns } from 'node:child_process'
 
-const { info, addPath, spawnSync, fetchReleaseAsset, chmodSyncMock } = vi.hoisted(() => ({
-  info: vi.fn(),
-  addPath: vi.fn(),
-  spawnSync: vi.fn(),
-  fetchReleaseAsset: vi.fn(),
-  chmodSyncMock: vi.fn(),
-}))
+const { info, addPath, spawnSync, fetchReleaseAsset, chmodSyncMock } =
+  vi.hoisted(() => ({
+    info: vi.fn(),
+    addPath: vi.fn(),
+    spawnSync: vi.fn(),
+    fetchReleaseAsset: vi.fn(),
+    chmodSyncMock: vi.fn(),
+  }))
 
 vi.mock('@actions/core', () => ({
   info,
@@ -18,7 +28,10 @@ vi.mock('@actions/core', () => ({
 }))
 
 vi.mock('node:child_process', async () => {
-  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+  const actual =
+    await vi.importActual<typeof import('node:child_process')>(
+      'node:child_process',
+    )
   return {
     ...actual,
     spawnSync,
@@ -41,7 +54,7 @@ vi.mock('node:fs', async () => {
     chmodSync: (...args: any[]) => {
       chmodSyncMock(...args)
       actual.chmodSync(args[0], args[1])
-    }
+    },
   }
 })
 
@@ -63,12 +76,22 @@ describe('app install release orchestration', () => {
     cacheRoot = mkdtempSync(join(baseTemp, 'setup-jlo-cache-'))
     tempDirectory = mkdtempSync(join(baseTemp, 'setup-jlo-tmp-'))
 
-    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
-      if (command.endsWith('jlo') && args.includes('--version')) {
-        return { status: 0, stdout: 'jlo 1.2.3', stderr: '' } as SpawnSyncReturns<string>
-      }
-      return { status: 1, stdout: '', stderr: 'Command not found' } as SpawnSyncReturns<string>
-    })
+    spawnSync.mockImplementation(
+      (command: string, args: string[], options: any) => {
+        if (command.endsWith('jlo') && args.includes('--version')) {
+          return {
+            status: 0,
+            stdout: 'jlo 1.2.3',
+            stderr: '',
+          } as SpawnSyncReturns<string>
+        }
+        return {
+          status: 1,
+          stdout: '',
+          stderr: 'Command not found',
+        } as SpawnSyncReturns<string>
+      },
+    )
   })
 
   afterEach(() => {
@@ -130,7 +153,10 @@ describe('app install release orchestration', () => {
 
     expect(existsSync(installedBinary)).toBe(true)
     expect(statSync(installedBinary).size).toBeGreaterThan(0)
-    expect(chmodSyncMock).toHaveBeenCalledWith(expect.stringContaining('jlo-linux-x86_64'), 0o755)
+    expect(chmodSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('jlo-linux-x86_64'),
+      0o755,
+    )
 
     expect(info).toHaveBeenCalledWith('jlo installed: jlo 1.2.3')
     expect(addPath).toHaveBeenCalledWith(installDir)

--- a/tests/app/install-release.test.ts
+++ b/tests/app/install-release.test.ts
@@ -2,25 +2,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
   mkdirSync,
-  chmodSync,
   readdirSync,
 } from 'node:fs'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
 import type { SpawnSyncReturns } from 'node:child_process'
 
-const { info, addPath, spawnSync, fetchReleaseAsset, chmodSyncMock } =
-  vi.hoisted(() => ({
-    info: vi.fn(),
-    addPath: vi.fn(),
-    spawnSync: vi.fn(),
-    fetchReleaseAsset: vi.fn(),
-    chmodSyncMock: vi.fn(),
-  }))
+const {
+  info,
+  addPath,
+  spawnSync,
+  fetchReleaseAsset,
+  chmodSyncMock,
+  detectPlatformTuple,
+} = vi.hoisted(() => ({
+  info: vi.fn(),
+  addPath: vi.fn(),
+  spawnSync: vi.fn(),
+  fetchReleaseAsset: vi.fn(),
+  chmodSyncMock: vi.fn(),
+  detectPlatformTuple: vi.fn(() => ({ os: 'linux', arch: 'x86_64' })),
+}))
 
 vi.mock('@actions/core', () => ({
   info,
@@ -38,12 +44,13 @@ vi.mock('node:child_process', async () => {
   }
 })
 
-vi.mock('node:os', async () => {
-  const actual = await vi.importActual<typeof import('node:os')>('node:os')
+vi.mock('../../src/domain/platform', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../src/domain/platform')
+  >('../../src/domain/platform')
   return {
     ...actual,
-    platform: () => 'linux',
-    arch: () => 'x64',
+    detectPlatformTuple,
   }
 })
 
@@ -51,9 +58,9 @@ vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
   return {
     ...actual,
-    chmodSync: (...args: any[]) => {
-      chmodSyncMock(...args)
-      actual.chmodSync(args[0], args[1])
+    chmodSync: (path: string, mode: number) => {
+      chmodSyncMock(path, mode)
+      actual.chmodSync(path, mode)
     },
   }
 })
@@ -67,31 +74,31 @@ import { installReleaseVersion } from '../../src/app/install-release'
 describe('app install release orchestration', () => {
   let cacheRoot: string
   let tempDirectory: string
+  let tempRoot: string
+  const platformDirName = 'linux-x86_64'
 
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // Set up real temp directories for the tests
-    const baseTemp = tmpdir()
-    cacheRoot = mkdtempSync(join(baseTemp, 'setup-jlo-cache-'))
-    tempDirectory = mkdtempSync(join(baseTemp, 'setup-jlo-tmp-'))
+    tempRoot = join(process.cwd(), '.tmp')
+    mkdirSync(tempRoot, { recursive: true })
+    cacheRoot = mkdtempSync(join(tempRoot, 'setup-jlo-cache-'))
+    tempDirectory = mkdtempSync(join(tempRoot, 'setup-jlo-tmp-'))
 
-    spawnSync.mockImplementation(
-      (command: string, args: string[], options: any) => {
-        if (command.endsWith('jlo') && args.includes('--version')) {
-          return {
-            status: 0,
-            stdout: 'jlo 1.2.3',
-            stderr: '',
-          } as SpawnSyncReturns<string>
-        }
+    spawnSync.mockImplementation((command: string, args: string[]) => {
+      if (command.endsWith('jlo') && args.includes('--version')) {
         return {
-          status: 1,
-          stdout: '',
-          stderr: 'Command not found',
+          status: 0,
+          stdout: 'jlo 1.2.3',
+          stderr: '',
         } as SpawnSyncReturns<string>
-      },
-    )
+      }
+      return {
+        status: 1,
+        stdout: '',
+        stderr: 'Command not found',
+      } as SpawnSyncReturns<string>
+    })
   })
 
   afterEach(() => {
@@ -100,7 +107,7 @@ describe('app install release orchestration', () => {
   })
 
   it('reuses cached release binary and skips release download', async () => {
-    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const platformDir = join(cacheRoot, platformDirName)
     const installDir = join(platformDir, 'v1.2.3')
     mkdirSync(installDir, { recursive: true })
     writeFileSync(join(installDir, 'jlo'), 'cached-binary')
@@ -125,12 +132,15 @@ describe('app install release orchestration', () => {
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo 1.2.3')
     expect(addPath).toHaveBeenCalledWith(installDir)
+    expect(readFileSync(join(installDir, 'jlo'), 'utf8')).toBe('cached-binary')
+    expect(readdirSync(tempDirectory)).toHaveLength(0)
   })
 
   it('downloads release asset and places it in cache', async () => {
+    const downloadedBinary = 'mock-downloaded-binary'
     fetchReleaseAsset.mockResolvedValue({
       name: 'jlo-linux-x86_64',
-      contents: Buffer.from('mock-downloaded-binary'),
+      contents: Buffer.from(downloadedBinary),
     })
 
     await installReleaseVersion(
@@ -147,19 +157,17 @@ describe('app install release orchestration', () => {
       },
     )
 
-    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const platformDir = join(cacheRoot, platformDirName)
     const installDir = join(platformDir, 'v1.2.3')
     const installedBinary = join(installDir, 'jlo')
 
     expect(existsSync(installedBinary)).toBe(true)
     expect(statSync(installedBinary).size).toBeGreaterThan(0)
-    expect(chmodSyncMock).toHaveBeenCalledWith(
-      expect.stringContaining('jlo-linux-x86_64'),
-      0o755,
-    )
-
+    expect(readFileSync(installedBinary, 'utf8')).toBe(downloadedBinary)
+    expect(statSync(installedBinary).mode & 0o777).toBe(0o755)
     expect(info).toHaveBeenCalledWith('jlo installed: jlo 1.2.3')
     expect(addPath).toHaveBeenCalledWith(installDir)
+    expect(readdirSync(tempDirectory)).toHaveLength(0)
   })
 
   it('fails and cleans up temp directory if downloaded asset is empty', async () => {

--- a/tests/app/install-release.test.ts
+++ b/tests/app/install-release.test.ts
@@ -1,73 +1,49 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync, mkdirSync, chmodSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { SpawnSyncReturns } from 'node:child_process'
 
-const {
-  info,
-  detectPlatformTuple,
-  buildReleaseAssetCandidates,
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  isCachedBinaryForVersion,
-  pruneSiblingInstallDirectories,
-  installBinaryOnPath,
-  detectBinaryVersion,
-  fetchReleaseAsset,
-  ensureExecutablePermissions,
-  mkdtempSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-  tmpdir,
-} = vi.hoisted(() => ({
+const { info, addPath, spawnSync, fetchReleaseAsset, chmodSyncMock } = vi.hoisted(() => ({
   info: vi.fn(),
-  detectPlatformTuple: vi.fn(),
-  buildReleaseAssetCandidates: vi.fn(),
-  resolvePlatformCacheDirectory: vi.fn(),
-  ensureInstallDirectory: vi.fn(),
-  isCachedBinaryForVersion: vi.fn(),
-  pruneSiblingInstallDirectories: vi.fn(),
-  installBinaryOnPath: vi.fn(),
-  detectBinaryVersion: vi.fn(),
+  addPath: vi.fn(),
+  spawnSync: vi.fn(),
   fetchReleaseAsset: vi.fn(),
-  ensureExecutablePermissions: vi.fn(),
-  mkdtempSync: vi.fn(),
-  renameSync: vi.fn(),
-  rmSync: vi.fn(),
-  statSync: vi.fn(),
-  writeFileSync: vi.fn(),
-  tmpdir: vi.fn(),
+  chmodSyncMock: vi.fn(),
 }))
 
 vi.mock('@actions/core', () => ({
   info,
+  addPath,
 }))
 
-vi.mock('node:fs', () => ({
-  mkdtempSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-}))
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+  return {
+    ...actual,
+    spawnSync,
+  }
+})
 
-vi.mock('node:os', () => ({
-  tmpdir,
-}))
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os')
+  return {
+    ...actual,
+    platform: () => 'linux',
+    arch: () => 'x64',
+  }
+})
 
-vi.mock('../../src/domain/platform', () => ({
-  detectPlatformTuple,
-  buildReleaseAssetCandidates,
-}))
-
-vi.mock('../../src/adapters/cache/binary-install-cache', () => ({
-  resolvePlatformCacheDirectory,
-  ensureInstallDirectory,
-  isCachedBinaryForVersion,
-  pruneSiblingInstallDirectories,
-  installBinaryOnPath,
-  detectBinaryVersion,
-  ensureExecutablePermissions,
-}))
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return {
+    ...actual,
+    chmodSync: (...args: any[]) => {
+      chmodSyncMock(...args)
+      actual.chmodSync(args[0], args[1])
+    }
+  }
+})
 
 vi.mock('../../src/adapters/github/release-asset-api', () => ({
   fetchReleaseAsset,
@@ -76,26 +52,42 @@ vi.mock('../../src/adapters/github/release-asset-api', () => ({
 import { installReleaseVersion } from '../../src/app/install-release'
 
 describe('app install release orchestration', () => {
-  const MOCK_TMP_DIR = '/tmp'
-  const MOCK_DOWNLOAD_PATH = '/tmp/setup-jlo-release-1234'
+  let cacheRoot: string
+  let tempDirectory: string
 
   beforeEach(() => {
     vi.clearAllMocks()
-    detectPlatformTuple.mockReturnValue({ os: 'linux', arch: 'x86_64' })
-    buildReleaseAssetCandidates.mockReturnValue(['jlo-linux-x86_64'])
-    resolvePlatformCacheDirectory.mockReturnValue('/cache/linux-x86_64')
-    ensureInstallDirectory.mockReturnValue('/cache/linux-x86_64/v1.2.3')
-    isCachedBinaryForVersion.mockReturnValue(true)
-    detectBinaryVersion.mockReturnValue('jlo 1.2.3')
+
+    // Set up real temp directories for the tests
+    const baseTemp = tmpdir()
+    cacheRoot = mkdtempSync(join(baseTemp, 'setup-jlo-cache-'))
+    tempDirectory = mkdtempSync(join(baseTemp, 'setup-jlo-tmp-'))
+
+    spawnSync.mockImplementation((command: string, args: string[], options: any) => {
+      if (command.endsWith('jlo') && args.includes('--version')) {
+        return { status: 0, stdout: 'jlo 1.2.3', stderr: '' } as SpawnSyncReturns<string>
+      }
+      return { status: 1, stdout: '', stderr: 'Command not found' } as SpawnSyncReturns<string>
+    })
+  })
+
+  afterEach(() => {
+    rmSync(cacheRoot, { recursive: true, force: true })
+    rmSync(tempDirectory, { recursive: true, force: true })
   })
 
   it('reuses cached release binary and skips release download', async () => {
+    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const installDir = join(platformDir, 'v1.2.3')
+    mkdirSync(installDir, { recursive: true })
+    writeFileSync(join(installDir, 'jlo'), 'cached-binary')
+
     await installReleaseVersion(
       {
         token: 'token',
         allowDarwinX8664Fallback: false,
-        cacheRoot: '/cache',
-        tempDirectory: '/tmp',
+        cacheRoot,
+        tempDirectory,
       },
       {
         kind: 'release-tag',
@@ -104,31 +96,59 @@ describe('app install release orchestration', () => {
       },
     )
 
-    expect(buildReleaseAssetCandidates).not.toHaveBeenCalled()
     expect(fetchReleaseAsset).not.toHaveBeenCalled()
     expect(info).toHaveBeenCalledWith(
       'jlo 1.2.3 already cached; skipping download.',
     )
     expect(info).toHaveBeenCalledWith('jlo installed: jlo 1.2.3')
+    expect(addPath).toHaveBeenCalledWith(installDir)
+  })
+
+  it('downloads release asset and places it in cache', async () => {
+    fetchReleaseAsset.mockResolvedValue({
+      name: 'jlo-linux-x86_64',
+      contents: Buffer.from('mock-downloaded-binary'),
+    })
+
+    await installReleaseVersion(
+      {
+        token: 'token',
+        allowDarwinX8664Fallback: false,
+        cacheRoot,
+        tempDirectory,
+      },
+      {
+        kind: 'release-tag',
+        version: '1.2.3',
+        tag: 'v1.2.3',
+      },
+    )
+
+    const platformDir = join(cacheRoot, 'linux-x86_64')
+    const installDir = join(platformDir, 'v1.2.3')
+    const installedBinary = join(installDir, 'jlo')
+
+    expect(existsSync(installedBinary)).toBe(true)
+    expect(statSync(installedBinary).size).toBeGreaterThan(0)
+    expect(chmodSyncMock).toHaveBeenCalledWith(expect.stringContaining('jlo-linux-x86_64'), 0o755)
+
+    expect(info).toHaveBeenCalledWith('jlo installed: jlo 1.2.3')
+    expect(addPath).toHaveBeenCalledWith(installDir)
   })
 
   it('fails and cleans up temp directory if downloaded asset is empty', async () => {
-    isCachedBinaryForVersion.mockReturnValue(false)
-    tmpdir.mockReturnValue(MOCK_TMP_DIR)
-    mkdtempSync.mockReturnValue(MOCK_DOWNLOAD_PATH)
     fetchReleaseAsset.mockResolvedValue({
       name: 'jlo-linux-x86_64',
       contents: Buffer.from(''),
     })
-    statSync.mockReturnValue({ size: 0 })
 
     await expect(
       installReleaseVersion(
         {
           token: 'token',
           allowDarwinX8664Fallback: false,
-          cacheRoot: '/cache',
-          tempDirectory: '/tmp',
+          cacheRoot,
+          tempDirectory,
         },
         {
           kind: 'release-tag',
@@ -140,22 +160,18 @@ describe('app install release orchestration', () => {
       "Downloaded release asset 'jlo-linux-x86_64' is missing or empty in 'asterismhq/jlo' (v1.2.3).",
     )
 
-    expect(rmSync).toHaveBeenCalledWith(MOCK_DOWNLOAD_PATH, {
-      recursive: true,
-      force: true,
-    })
+    // Verify temp directory was cleaned up
+    const tempDirContents = readdirSync(tempDirectory)
+    expect(tempDirContents.length).toBe(0)
   })
 
   it('cleans up temp directory if ensureExecutablePermissions throws', async () => {
-    isCachedBinaryForVersion.mockReturnValue(false)
-    tmpdir.mockReturnValue(MOCK_TMP_DIR)
-    mkdtempSync.mockReturnValue(MOCK_DOWNLOAD_PATH)
     fetchReleaseAsset.mockResolvedValue({
       name: 'jlo-linux-x86_64',
-      contents: Buffer.from('binary-data'),
+      contents: Buffer.from('mock-downloaded-binary'),
     })
-    statSync.mockReturnValue({ size: 100 })
-    ensureExecutablePermissions.mockImplementation(() => {
+
+    chmodSyncMock.mockImplementationOnce(() => {
       throw new Error('Permission denied')
     })
 
@@ -164,8 +180,8 @@ describe('app install release orchestration', () => {
         {
           token: 'token',
           allowDarwinX8664Fallback: false,
-          cacheRoot: '/cache',
-          tempDirectory: '/tmp',
+          cacheRoot,
+          tempDirectory,
         },
         {
           kind: 'release-tag',
@@ -175,9 +191,8 @@ describe('app install release orchestration', () => {
       ),
     ).rejects.toThrow('Permission denied')
 
-    expect(rmSync).toHaveBeenCalledWith(MOCK_DOWNLOAD_PATH, {
-      recursive: true,
-      force: true,
-    })
+    // Verify temp directory was cleaned up
+    const tempDirContents = readdirSync(tempDirectory)
+    expect(tempDirContents.length).toBe(0)
   })
 })


### PR DESCRIPTION
Refactored `tests/app/install-main-source.test.ts` and `tests/app/install-release.test.ts` to assert on observable behaviors rather than internal domain and adapter spy interactions.

Both test files now utilize a real temporary directory for testing the cache and temp download logic and mock at the network and process boundaries (e.g., node:os, node:child_process, and GitHub api endpoints).

Additionally, teardowns enforce cleanup on temp test artifacts.

---
*PR created automatically by Jules for task [11949693372128936404](https://jules.google.com/task/11949693372128936404) started by @akitorahayashi*